### PR TITLE
fix: init_process_group failed when using ipv6 master address

### DIFF
--- a/trinity/cli/launcher.py
+++ b/trinity/cli/launcher.py
@@ -129,7 +129,8 @@ def run(config_path: str):
         data_config.dj_config_path or data_config.dj_process_desc
     ):
         activate_data_module(data_config.data_workflow_url, config_path)
-    ray.init()
+    if not ray.is_initialized():
+        ray.init()
     if config.mode == "explore":
         explore(config)
     elif config.mode == "train":

--- a/trinity/utils/distributed.py
+++ b/trinity/utils/distributed.py
@@ -2,6 +2,7 @@
 """For distributed training with multiple process groups."""
 from datetime import timedelta
 from typing import Any, Optional, Union
+import ipaddress
 
 import torch
 from torch.distributed.distributed_c10d import (
@@ -14,6 +15,12 @@ from torch.distributed.distributed_c10d import (
     rendezvous,
 )
 
+def is_ipv6_address(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return isinstance(ip, ipaddress.IPv6Address)
+    except ValueError:
+        return False
 
 def init_process_group(
     backend: Union[str, Backend] = None,

--- a/trinity/utils/distributed.py
+++ b/trinity/utils/distributed.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """For distributed training with multiple process groups."""
+import ipaddress
 from datetime import timedelta
 from typing import Any, Optional, Union
-import ipaddress
 
 import torch
 from torch.distributed.distributed_c10d import (
@@ -15,12 +15,14 @@ from torch.distributed.distributed_c10d import (
     rendezvous,
 )
 
+
 def is_ipv6_address(ip_str: str) -> bool:
     try:
         ip = ipaddress.ip_address(ip_str)
         return isinstance(ip, ipaddress.IPv6Address)
     except ValueError:
         return False
+
 
 def init_process_group(
     backend: Union[str, Backend] = None,

--- a/trinity/utils/monitor.py
+++ b/trinity/utils/monitor.py
@@ -4,9 +4,9 @@ from typing import Any, List, Optional, Union
 
 import numpy as np
 import pandas as pd
-import wandb
 from torch.utils.tensorboard import SummaryWriter
 
+import wandb
 from trinity.common.constants import MonitorType
 from trinity.utils.log import get_logger
 

--- a/trinity/utils/monitor.py
+++ b/trinity/utils/monitor.py
@@ -4,9 +4,9 @@ from typing import Any, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+import wandb
 from torch.utils.tensorboard import SummaryWriter
 
-import wandb
 from trinity.common.constants import MonitorType
 from trinity.utils.log import get_logger
 


### PR DESCRIPTION
## Description

when using ipv6 master address, the torch.distributed.distributed_c10d.rendezvous can not parse `init_method` correctly, since it use urllib which expected ipv6:port to be `[ipv6]:port`

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [x]  Code is ready for review
