### PR TITLE
Support custom monitor

### DIFF
--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -279,6 +279,8 @@ class TrainerConfig:
 class MonitorConfig:
     # TODO: support multiple monitors (List[MonitorType])
     monitor_type: MonitorType = MonitorType.WANDB
+    # the default args for monitor
+    monitor_args: Dict = field(default_factory=dict)
     # ! DO NOT SET, automatically generated as checkpoint_job_dir/monitor
     cache_dir: str = ""
 

--- a/trinity/explorer/explorer.py
+++ b/trinity/explorer/explorer.py
@@ -20,7 +20,7 @@ from trinity.common.models.utils import (
 from trinity.explorer.runner_pool import RunnerPool
 from trinity.manager.manager import CacheManager
 from trinity.utils.log import get_logger
-from trinity.utils.monitor import Monitor
+from trinity.utils.monitor import MONITOR
 
 
 @ray.remote(name="explorer", concurrency_groups={"get_weight": 32, "setup_weight_sync_group": 1})
@@ -47,7 +47,7 @@ class Explorer:
         for eval_taskset_config in self.config.buffer.explorer_input.eval_tasksets:
             self.eval_tasksets.append(get_buffer_reader(eval_taskset_config, self.config.buffer))
         self.runner_pool = self._init_runner_pool()
-        self.monitor = Monitor(
+        self.monitor = MONITOR.get(self.config.monitor.monitor_type)(
             project=self.config.project,
             name=self.config.name,
             role="explorer",

--- a/trinity/trainer/verl_trainer.py
+++ b/trinity/trainer/verl_trainer.py
@@ -34,7 +34,7 @@ from trinity.trainer.verl.ray_trainer import (
     pprint,
     reduce_metrics,
 )
-from trinity.utils.monitor import Monitor
+from trinity.utils.monitor import MONITOR
 
 
 class _InternalDataLoader:
@@ -128,7 +128,7 @@ class VerlPPOTrainerWrapper(RayPPOTrainer, TrainEngineWrapper):
         self.algorithm_type = (
             AlgorithmType.PPO
         )  # TODO: initialize algorithm_type according to config
-        self.logger = Monitor(
+        self.logger = MONITOR.get(global_config.monitor.monitor_type)(
             project=config.trainer.project_name,
             name=config.trainer.experiment_name,
             role="trainer",

--- a/trinity/utils/monitor.py
+++ b/trinity/utils/monitor.py
@@ -1,5 +1,7 @@
 """Monitor"""
+
 import os
+from abc import ABC, abstractmethod
 from typing import List, Optional, Union
 
 import numpy as np
@@ -8,11 +10,13 @@ import wandb
 from torch.utils.tensorboard import SummaryWriter
 
 from trinity.common.config import Config
-from trinity.common.constants import MonitorType
 from trinity.utils.log import get_logger
+from trinity.utils.registry import Registry
+
+MONITOR = Registry("monitor")
 
 
-class Monitor:
+class Monitor(ABC):
     """Monitor"""
 
     def __init__(
@@ -22,15 +26,25 @@ class Monitor:
         role: str,
         config: Config = None,  # pass the global Config for recording
     ) -> None:
-        if config.monitor.monitor_type == MonitorType.WANDB:
-            self.logger = WandbLogger(project, name, role, config)
-        elif config.monitor.monitor_type == MonitorType.TENSORBOARD:
-            self.logger = TensorboardLogger(project, name, role, config)
-        else:
-            raise ValueError(f"Unknown monitor type: {config.monitor.monitor_type}")
+        self.project = project
+        self.name = name
+        self.role = role
+        self.config = config
 
+    @abstractmethod
     def log_table(self, table_name: str, experiences_table: pd.DataFrame, step: int):
-        self.logger.log_table(table_name, experiences_table, step=step)
+        """Log a table"""
+
+    @abstractmethod
+    def log(self, data: dict, step: int, commit: bool = False) -> None:
+        """Log metrics."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the monitor"""
+
+    def __del__(self) -> None:
+        self.close()
 
     def calculate_metrics(
         self, data: dict[str, Union[List[float], float]], prefix: Optional[str] = None
@@ -51,15 +65,9 @@ class Monitor:
                 metrics[key] = val
         return metrics
 
-    def log(self, data: dict, step: int, commit: bool = False) -> None:
-        """Log metrics."""
-        self.logger.log(data, step=step, commit=commit)
 
-    def close(self) -> None:
-        self.logger.close()
-
-
-class TensorboardLogger:
+@MONITOR.register("tensorboard")
+class TensorboardMonitor(Monitor):
     def __init__(self, project: str, name: str, role: str, config: Config = None) -> None:
         self.tensorboard_dir = os.path.join(config.monitor.cache_dir, "tensorboard")
         os.makedirs(self.tensorboard_dir, exist_ok=True)
@@ -77,11 +85,9 @@ class TensorboardLogger:
     def close(self) -> None:
         self.logger.close()
 
-    def __del__(self) -> None:
-        self.logger.close()
 
-
-class WandbLogger:
+@MONITOR.register_module("wandb")
+class WandbMonitor(Monitor):
     def __init__(self, project: str, name: str, role: str, config: Config = None) -> None:
         self.logger = wandb.init(
             project=project,
@@ -103,7 +109,4 @@ class WandbLogger:
         self.console_logger.info(f"Step {step}: {data}")
 
     def close(self) -> None:
-        self.logger.finish()
-
-    def __del__(self) -> None:
         self.logger.finish()


### PR DESCRIPTION
## Description

1. Add monitor registration points (`trinity.utils.monitor.MONITOR`) to allow users to register their own monitors
2. Add `monitor.monitor_args` to facilitate initialization

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
