### PR TITLE
Fix BasicEntropyLossFn

### DIFF
--- a/docs/sphinx_doc/source/tutorial/trinity_programming_guide.md
+++ b/docs/sphinx_doc/source/tutorial/trinity_programming_guide.md
@@ -299,7 +299,7 @@ pip install -e .[dev]
 # pip install -e .\[dev\]
 
 # Run code style checks
-pre-commit --all-files
+pre-commit run --all-files
 
 # Commit the code after all checks pass
 git commit -am "create example workflow"

--- a/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
+++ b/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
@@ -38,6 +38,7 @@ class EntropyLossFn(ABC):
         Returns:
             `Dict`: The default arguments for the entropy loss function.
         """
+        return {"entropy_coef": 0.0}
 
 
 @ENTROPY_LOSS_FN.register_module("basic")


### PR DESCRIPTION
1. Init BasicEntropyLossFn default_args entropy_coef using zero, otherwise, check_and_update will be error.
2. Fix writing typo in programming_guide