### PR TITLE
Fix BasicEntropyLossFn

### DIFF
--- a/docs/sphinx_doc/source/tutorial/trinity_programming_guide.md
+++ b/docs/sphinx_doc/source/tutorial/trinity_programming_guide.md
@@ -299,7 +299,7 @@ pip install -e .[dev]
 # pip install -e .\[dev\]
 
 # Run code style checks
-pre-commit --all-files
+pre-commit run --all-files
 
 # Commit the code after all checks pass
 git commit -am "create example workflow"

--- a/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
+++ b/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
@@ -38,6 +38,7 @@ class EntropyLossFn(ABC):
         Returns:
             `Dict`: The default arguments for the entropy loss function.
         """
+        return {"entropy_coef": 0.0}
 
 
 @ENTROPY_LOSS_FN.register_module("basic")

--- a/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
+++ b/trinity/algorithm/entropy_loss_fn/entropy_loss_fn.py
@@ -16,10 +16,10 @@ class EntropyLossFn(ABC):
 
     @abstractmethod
     def __call__(
-        self,
-        entropy: torch.Tensor,
-        action_mask: torch.Tensor,
-        **kwargs,
+            self,
+            entropy: torch.Tensor,
+            action_mask: torch.Tensor,
+            **kwargs,
     ) -> Tuple[torch.Tensor, Dict]:
         """
         Args:
@@ -32,7 +32,6 @@ class EntropyLossFn(ABC):
         """
 
     @classmethod
-    @abstractmethod
     def default_args(cls) -> Dict:
         """
         Returns:
@@ -51,17 +50,13 @@ class BasicEntropyLossFn(EntropyLossFn):
         self.entropy_coef = entropy_coef
 
     def __call__(
-        self,
-        entropy: torch.Tensor,
-        action_mask: torch.Tensor,
-        **kwargs,
+            self,
+            entropy: torch.Tensor,
+            action_mask: torch.Tensor,
+            **kwargs,
     ) -> Tuple[torch.Tensor, Dict]:
         entropy_loss = masked_mean(entropy, action_mask)
         return entropy_loss * self.entropy_coef, {"entropy_loss": entropy_loss.detach().item()}
-
-    @classmethod
-    def default_args(cls) -> Dict:
-        return {"entropy_coef": 0.0}
 
 
 @ENTROPY_LOSS_FN.register_module("none")
@@ -74,13 +69,9 @@ class DummyEntropyLossFn(EntropyLossFn):
         pass
 
     def __call__(
-        self,
-        entropy: torch.Tensor,
-        action_mask: torch.Tensor,
-        **kwargs,
+            self,
+            entropy: torch.Tensor,
+            action_mask: torch.Tensor,
+            **kwargs,
     ) -> Tuple[torch.Tensor, Dict]:
         return torch.tensor(0.0), {}
-
-    @classmethod
-    def default_args(cls) -> Dict:
-        return {}


### PR DESCRIPTION
1. Init BasicEntropyLossFn default_args entropy_coef using zero, otherwise, check_and_update will be error.
2. fix writting typo in programming_guide