### PR TITLE
Split group of tasks to multiple runners

### DIFF
--- a/docs/sphinx_doc/source/tutorial/example_mix_algo.md
+++ b/docs/sphinx_doc/source/tutorial/example_mix_algo.md
@@ -137,7 +137,7 @@ We also need to add an `is_expert_mask` field when transforming to DataProto to 
     cumsum = torch.cumsum(attention_mask, dim=-1)
     position_ids = torch.clip(cumsum - 1, 0, None).long()
     batch_dict = {
-        "uid": np.array(experiences.run_ids),
+        "uid": np.array(experiences.group_ids),
         "position_ids": position_ids,
         "input_ids": experiences.tokens.long(),
         "responses": experiences.tokens[:, experiences.prompt_length :].long(),

--- a/tests/buffer/queue_test.py
+++ b/tests/buffer/queue_test.py
@@ -68,7 +68,7 @@ class TestQueueBuffer(RayUnittestBaseAysnc):
         with open(BUFFER_FILE_PATH, "r") as f:
             self.assertEqual(len(f.readlines()), total_num + put_batch_size * 2)
         st = time.time()
-        self.assertRaises(StopIteration, reader.read, batch_size=1)
+        self.assertRaises(TimeoutError, reader.read, batch_size=1)
         et = time.time()
         self.assertTrue(et - st > 2)
 

--- a/tests/explorer/scheduler_test.py
+++ b/tests/explorer/scheduler_test.py
@@ -8,7 +8,7 @@ import torch
 
 from tests.tools import get_template_config
 from trinity.buffer.reader.queue_reader import QueueReader
-from trinity.common.config import StorageConfig
+from trinity.common.config import GenerationConfig, StorageConfig
 from trinity.common.constants import StorageType
 from trinity.common.experience import Experience
 from trinity.common.models.model import InferenceModel
@@ -23,6 +23,7 @@ class DummyWorkflow(Workflow):
         super().__init__(model, task, auxiliary_models)
         self.error_type = task.raw_task.get("error_type", "")
         self.seconds = None
+        self.repeat_times = task.rollout_args.n
         if "timeout" in self.error_type:
             parts = self.error_type.split("_")
             if len(parts) > 1:
@@ -42,8 +43,12 @@ class DummyWorkflow(Workflow):
 
         return [
             Experience(
-                tokens=torch.zeros(5), prompt_length=2, prompt_text=self.error_type or "success"
+                tokens=torch.zeros(5),
+                prompt_length=2,
+                prompt_text=self.error_type or "success",
+                info={"repeat_times": self.repeat_times},
             )
+            for _ in range(self.repeat_times)
         ]
 
 
@@ -98,7 +103,11 @@ class DummyAuxiliaryModel(InferenceModel):
 
 
 def generate_tasks(
-    total_num: int, timeout_num: int = 0, exception_num: int = 0, timeout_seconds: int = 10
+    total_num: int,
+    timeout_num: int = 0,
+    exception_num: int = 0,
+    timeout_seconds: int = 10,
+    repeat_times: int = 1,
 ):
     """Generate some tasks for testing
 
@@ -108,7 +117,10 @@ def generate_tasks(
         exception_num: number of exception tasks
         timeout_seconds: the timeout for timeout tasks
     """
-    tasks = [Task(workflow=DummyWorkflow, raw_task={}) for _ in range(total_num)]
+    tasks = [
+        Task(workflow=DummyWorkflow, raw_task={}, rollout_args=GenerationConfig(n=repeat_times))
+        for _ in range(total_num)
+    ]
 
     tasks.extend(
         [
@@ -150,6 +162,9 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
             algorithm_type="ppo",
             path="",
         )
+        self.config.buffer.trainer_input.experience_buffer.max_read_timeout = 1
+        self.config.algorithm.repeat_times = 1
+        self.config.check_and_update()
         self.queue = QueueReader(
             self.config.buffer.trainer_input.experience_buffer, self.config.buffer
         )
@@ -163,6 +178,9 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
 
         results = await scheduler.get_results(batch_id=0, min_num=8, timeout=20)
         self.assertEqual(len(results), 8)
+        self.assertEqual(len(self.queue.read(batch_size=8)), 8)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
 
         for result in results:
             self.assertTrue(result.ok)
@@ -176,6 +194,9 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
             results = await scheduler.get_results(batch_id=batch_id, min_num=4, timeout=10)
             self.assertEqual(len(results), 4)
             self.assertFalse(scheduler.has_step(batch_id))
+            self.assertEqual(len(self.queue.read(batch_size=4)), 4)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
 
         tasks = generate_tasks(3)
         scheduler.schedule(tasks, batch_id=4)
@@ -183,6 +204,7 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
         results = await scheduler.get_results(batch_id=4)
         self.assertEqual(len(results), 3)
         self.assertFalse(scheduler.has_step(4))
+        self.assertEqual(len(self.queue.read(batch_size=3)), 3)
 
         # test timeout
         tasks = generate_tasks(2, timeout_num=2, timeout_seconds=10)
@@ -194,6 +216,7 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertLessEqual(end_time - start_time, 5)
         self.assertEqual(len(results), 2)
+        self.assertEqual(len(self.queue.read(batch_size=2)), 2)
 
         # test run tasks after timeout
         tasks = generate_tasks(4)
@@ -204,8 +227,10 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(results), 4)
 
         success_count = sum(1 for r in results if r.ok)
-
-        self.assertEqual(success_count, sum(1 for r in results if r.ok))
+        self.assertEqual(success_count, 4)
+        self.assertEqual(len(self.queue.read(batch_size=4)), 4)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
 
         # test exception tasks
         tasks = generate_tasks(1, exception_num=3)
@@ -215,14 +240,21 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
 
         success_count = sum(1 for r in results if r.ok)
         self.assertEqual(success_count, 1)
+        self.assertEqual(len(self.queue.read(batch_size=1)), 1)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
 
         # test clear_timeout_tasks
         tasks = generate_tasks(3, timeout_num=1, timeout_seconds=3)
         scheduler.schedule(tasks, batch_id=2)
         results = await scheduler.get_results(batch_id=2, timeout=2, clear_timeout_tasks=False)
         self.assertEqual(len(results), 3)
+        self.assertEqual(len(self.queue.read(batch_size=3)), 3)
         results = await scheduler.get_results(batch_id=2, timeout=2, clear_timeout_tasks=False)
         self.assertEqual(len(results), 1)
+        self.assertEqual(len(self.queue.read(batch_size=1)), 1)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
 
         await scheduler.stop()
 
@@ -364,6 +396,38 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(et - st < 1.0)
         self.assertEqual(len(results), 4)
         self.assertFalse(scheduler.has_step(2))
+        await scheduler.stop()
+
+    async def test_split_tasks(self):
+        self.config.explorer.max_repeat_times = 2
+        self.config.check_and_update()
+        scheduler = Scheduler(self.config, [DummyModel.remote(), DummyModel.remote()])
+        await scheduler.start()
+
+        tasks = generate_tasks(4, repeat_times=8)  # ceil(8 / 2) == 4
+        scheduler.schedule(tasks, batch_id=1)
+        results = await scheduler.get_results(batch_id=1)
+        self.assertEqual(len(results), 4 * 4)
+        self.assertEqual(len(self.queue.read(batch_size=4 * 8)), 4 * 8)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
+
+        tasks = generate_tasks(4, repeat_times=5)  # ceil(5 / 2) == 3
+        scheduler.schedule(tasks, batch_id=1)
+        results = await scheduler.get_results(batch_id=1)
+        self.assertEqual(len(results), 4 * 3)
+        self.assertEqual(len(self.queue.read(batch_size=4 * 5)), 4 * 5)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
+
+        tasks = generate_tasks(3, repeat_times=1)  # ceil(1 / 2) == 1
+        scheduler.schedule(tasks, batch_id=1)
+        results = await scheduler.get_results(batch_id=1)
+        self.assertEqual(len(results), 3 * 1)
+        self.assertEqual(len(self.queue.read(batch_size=3 * 1)), 3 * 1)
+        with self.assertRaises(TimeoutError):
+            self.queue.read(batch_size=1)
+
         await scheduler.stop()
 
     def tearDown(self):

--- a/tests/explorer/scheduler_test.py
+++ b/tests/explorer/scheduler_test.py
@@ -399,7 +399,7 @@ class SchedulerTest(unittest.IsolatedAsyncioTestCase):
         await scheduler.stop()
 
     async def test_split_tasks(self):
-        self.config.explorer.max_repeat_times = 2
+        self.config.explorer.max_repeat_times_per_runner = 2
         self.config.check_and_update()
         scheduler = Scheduler(self.config, [DummyModel.remote(), DummyModel.remote()])
         await scheduler.start()

--- a/trinity/algorithm/sample_strategy/mix_sample_strategy.py
+++ b/trinity/algorithm/sample_strategy/mix_sample_strategy.py
@@ -90,7 +90,7 @@ def to_data_proto_mix(experiences: Experiences, is_expert_mask: torch.tensor) ->
     cumsum = torch.cumsum(attention_mask, dim=-1)
     position_ids = torch.clip(cumsum - 1, 0, None).long()
     batch_dict = {
-        "uid": np.array(experiences.run_ids),
+        "uid": np.array(experiences.group_ids),
         "position_ids": position_ids,
         "input_ids": experiences.tokens.long(),
         "responses": experiences.tokens[:, experiences.prompt_length :].long(),

--- a/trinity/algorithm/sample_strategy/utils.py
+++ b/trinity/algorithm/sample_strategy/utils.py
@@ -13,7 +13,7 @@ def to_data_proto(experiences: Experiences) -> DataProto:
     cumsum = torch.cumsum(attention_mask, dim=-1)
     position_ids = torch.clip(cumsum - 1, 0, None).long()
     batch_dict = {
-        "uid": np.array(experiences.run_ids),
+        "uid": np.array(experiences.group_ids),
         "position_ids": position_ids,
         "input_ids": experiences.tokens.long(),
         "responses": experiences.tokens[:, experiences.prompt_length :].long(),

--- a/trinity/buffer/reader/queue_reader.py
+++ b/trinity/buffer/reader/queue_reader.py
@@ -31,7 +31,9 @@ class QueueReader(BufferReader):
             batch_size = batch_size or self.read_batch_size
             exps = ray.get(self.queue.get_batch.remote(batch_size, timeout=self.timeout))
             if len(exps) != batch_size:
-                raise StopIteration("Read incomplete batch, please check your workflow.")
+                raise TimeoutError(
+                    f"Read incomplete batch ({len(exps)}/{batch_size}), please check your workflow."
+                )
         except StopAsyncIteration:
             raise StopIteration()
         return exps

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -310,6 +310,9 @@ class ExplorerConfig:
     max_timeout: int = 1800  # wait each task for 30 minutes
     max_retry_times: int = 2  # retry each task for 2 times if it fails or timeout
     env_vars: dict = field(default_factory=dict)  # environment variables for workflow runner
+    max_repeat_times: Optional[
+        int
+    ] = None  # the number of time to repeat each task in a single workflow runner (for GRPO-like algorithms)
 
     runner_num: Optional[int] = None  # deprecated
 

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -310,7 +310,7 @@ class ExplorerConfig:
     max_timeout: int = 1800  # wait each task for 30 minutes
     max_retry_times: int = 2  # retry each task for 2 times if it fails or timeout
     env_vars: dict = field(default_factory=dict)  # environment variables for workflow runner
-    max_repeat_times: Optional[
+    max_repeat_times_per_runner: Optional[
         int
     ] = None  # the number of time to repeat each task in a single workflow runner (for GRPO-like algorithms)
 
@@ -361,9 +361,8 @@ class MonitorConfig:
 
 @dataclass
 class SynchronizerConfig:
-    """Configs for model weight synchronization"""
+    """Configs for model weight synchronization."""
 
-    # TODO: rename to "checkpoint", "nccl", "ipc"
     sync_method: SyncMethod = SyncMethod.NCCL
     # sync weights every `sync_interval` steps
     sync_interval: int = 1

--- a/trinity/common/experience.py
+++ b/trinity/common/experience.py
@@ -26,7 +26,7 @@ class Experience:
     rejected: Optional[Tensor] = None  # for dpo
     info: Optional[dict] = None
     metrics: Optional[dict[str, float]] = None
-    run_id: str = ""
+    group_id: str = ""  # for grpo
 
     def __post_init__(self):
         if self.action_mask is not None:
@@ -95,7 +95,7 @@ class Experiences:
     action_masks: Optional[Tensor]
     prompt_length: int
     logprobs: Optional[Tensor]
-    run_ids: List[str]
+    group_ids: List[str]
 
     @property
     def batch_size(self) -> int:
@@ -118,11 +118,11 @@ class Experiences:
                 action_masks=torch.empty(0, dtype=torch.bool),
                 logprobs=torch.empty(0, dtype=torch.float32),
                 prompt_length=torch.empty(0, dtype=torch.int32),
-                run_ids=[],
+                group_ids=[],
             )
         max_prompt_length = max([exp.prompt_length for exp in experiences])
         max_response_length = max([len(exp.tokens) - exp.prompt_length for exp in experiences])
-        run_ids = [exp.run_id for exp in experiences]
+        group_ids = [exp.group_id for exp in experiences]
         tokens_dtype = experiences[0].tokens.dtype
         tokens = torch.stack(
             [
@@ -208,7 +208,7 @@ class Experiences:
             logprobs = None
 
         return cls(
-            run_ids=run_ids,
+            group_ids=group_ids,
             tokens=tokens,
             rewards=rewards,
             attention_masks=attention_masks,
@@ -249,7 +249,7 @@ class Experiences:
                 action_masks=torch.empty(0, dtype=torch.bool),
                 logprobs=torch.empty(0, dtype=torch.float32),
                 prompt_length=torch.empty(0, dtype=torch.int32),
-                run_ids=[],
+                group_ids=[],
             )
 
         # TODO: exp.tokens in DPO are prompt tokens
@@ -261,7 +261,7 @@ class Experiences:
         response_tokens = list(chain.from_iterable(zip(chosen_tokens, rejected_tokens)))
         max_response_length = max([len(response) for response in response_tokens])  # type: ignore
 
-        run_ids = list(chain.from_iterable([repeat(exp.run_id, 2) for exp in experiences]))
+        group_ids = list(chain.from_iterable([repeat(exp.group_id, 2) for exp in experiences]))
         tokens_dtype = experiences[0].tokens.dtype
         tokens = torch.stack(
             [
@@ -297,7 +297,7 @@ class Experiences:
         assert len(tokens) == 2 * len(experiences)
 
         return cls(
-            run_ids=run_ids,
+            group_ids=group_ids,
             tokens=tokens,
             attention_masks=attention_masks,
             prompt_length=max_prompt_length,

--- a/trinity/common/workflows/workflow.py
+++ b/trinity/common/workflows/workflow.py
@@ -35,6 +35,8 @@ class Task:
     reward_fn: Optional[Type[RewardFn]] = None
     raw_task: Optional[dict] = None  # The raw data sample
 
+    group_id: Optional[str] = None  # for GRPO-like algorithms, automatically assigned
+
     def to_workflow(
         self, model: Any, auxiliary_models: Optional[List[openai.OpenAI]] = None
     ) -> Workflow:

--- a/trinity/explorer/scheduler.py
+++ b/trinity/explorer/scheduler.py
@@ -5,6 +5,7 @@ import re
 import time
 import traceback
 from collections import defaultdict, deque
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
 import ray
@@ -14,6 +15,15 @@ from trinity.common.models import InferenceModel
 from trinity.common.workflows import Task
 from trinity.explorer.workflow_runner import Status, WorkflowRunner
 from trinity.utils.log import get_logger
+
+
+@dataclass
+class TaskWrapper:
+    """A wrapper for a task."""
+
+    task: Task
+    batch_id: Union[int, str]
+    repeat_times: int
 
 
 class RunnerWrapper:
@@ -49,7 +59,7 @@ class RunnerWrapper:
             .remote(self.config, self.rollout_model, self.auxiliary_models)
         )
 
-    async def run_with_retry(self, task: Task) -> Tuple[Status, int]:
+    async def run_with_retry(self, task: TaskWrapper) -> Tuple[Status, int]:
         """
         Returns:
             `Status`: The return status of the task.
@@ -62,15 +72,16 @@ class RunnerWrapper:
         try:
             for attempt in range(self.retry_times + 1):
                 try:
-                    status = await asyncio.wait_for(self.runner.run_task.remote(task), self.timeout)
+                    task.task.rollout_args.n = task.repeat_times
+                    status = await asyncio.wait_for(
+                        self.runner.run_task.remote(task.task), self.timeout
+                    )
                     if status.ok:
                         break
                     else:
                         self.logger.error(status.message)
                 except asyncio.TimeoutError:
-                    last_exception_msg = (
-                        f"Timeout when running task at runner {self.runner_id}: {task}"
-                    )
+                    last_exception_msg = f"Timeout when running task of batch {task.batch_id} at runner {self.runner_id}: {task.task}"
                     self.logger.error(last_exception_msg)
                     status = Status(ok=False, metric=dict(), message=last_exception_msg)
                 except Exception:
@@ -123,18 +134,19 @@ class Scheduler:
         self.namespace = ray.get_runtime_context().namespace
         self.default_timeout = config.explorer.max_timeout * (config.explorer.max_retry_times + 1)
         self.max_retry_times = config.explorer.max_retry_times
+        self.max_repeat_times = config.explorer.max_repeat_times
         self.running = False
 
         self.runner_num = len(rollout_model) * config.explorer.runner_per_model
         self.runners: Dict[int, RunnerWrapper] = dict()
         self.idle_runners = set()  # runner_id
-        self.busy_runners = dict()  # runner_id -> (task, batch_id)
+        self.busy_runners = dict()  # runner_id -> task
 
-        self.pending_tasks_heap = []
         self.pending_tasks: Dict[Union[int, str], deque] = defaultdict(deque)  # batch_id -> tasks
         self.running_tasks: Dict[Union[int, str], set[asyncio.Future]] = defaultdict(
             set
         )  # batch_id -> futures
+        self.running_task_map: Dict[asyncio.Future, TaskWrapper] = dict()  # future -> task
         self.completed_tasks: Dict[Union[int, str], deque[Status]] = defaultdict(
             deque
         )  # batch_id -> results
@@ -166,9 +178,9 @@ class Scheduler:
         self.runners[runner_id].restart_runner()
 
         if runner_id in self.busy_runners:
-            task, idx = self.busy_runners.pop(runner_id)
+            task = self.busy_runners.pop(runner_id)
             self.logger.warning(
-                f"Runner {runner_id} failed to run task at batch_id {idx}: {task.raw_task}"
+                f"Runner {runner_id} failed to run task at batch_id {task.batch_id}: {task.task.raw_task}"
             )
 
         self.idle_runners.add(runner_id)
@@ -179,7 +191,6 @@ class Scheduler:
         while self.running:
             try:
                 await self._schedule_pending_tasks()
-                await self._check_completed_tasks()
                 await asyncio.sleep(0.01)
             except Exception:
                 self.logger.error(f"Error in scheduler loop:\n{traceback.format_exc()}")
@@ -197,36 +208,35 @@ class Scheduler:
             while task_queue and self.idle_runners:
                 task = task_queue.pop()
                 runner_id = self.idle_runners.pop()
-                self.busy_runners[runner_id] = (task, batch_id)
-                self.running_tasks[batch_id].add(
-                    asyncio.create_task(self.runners[runner_id].run_with_retry(task))
-                )
+                self.busy_runners[runner_id] = task
+                future = asyncio.create_task(self.runners[runner_id].run_with_retry(task))
+                self.running_task_map[future] = task
+                future.add_done_callback(self.task_done_callback)
+                self.running_tasks[batch_id].add(future)
 
             if not task_queue:
                 del self.pending_tasks[batch_id]
 
-    async def _check_completed_tasks(self) -> None:
-        for batch_id in list(self.running_tasks.keys()):
-            futures = self.running_tasks[batch_id]
+    def task_done_callback(self, async_task: asyncio.Task):
+        task = self.running_task_map.pop(async_task)
+        if async_task.cancelled():
+            return
+        elif async_task.exception():
+            self.logger.error(f"Task {task.task_id} failed: {async_task.exception()}")
+            return
+        else:
+            task_result, runner_id = async_task.result()
+            self.completed_tasks[task.batch_id].appendleft(task_result)
+            self.busy_runners.pop(runner_id)
+            self.idle_runners.add(runner_id)
+            self.logger.debug(
+                f"Task completed (batch_id {task.batch_id}), success: {task_result.ok}"
+            )
 
-            for future in list(futures):
-                if future.done():
-                    futures.remove(future)
-                    try:
-                        task_result, runner_id = await future
-                        self.completed_tasks[batch_id].appendleft(task_result)
-                        self.busy_runners.pop(runner_id)
-                        self.idle_runners.add(runner_id)
-
-                        self.logger.debug(
-                            f"Task completed (batch_id {batch_id}), success: {task_result.ok}"
-                        )
-
-                    except Exception as e:
-                        self.logger.error(f"Error getting task result: {e}")
-
-            if not futures:
-                del self.running_tasks[batch_id]
+        if task.batch_id in self.running_tasks:
+            self.running_tasks[task.batch_id].remove(async_task)
+            if not self.running_tasks[task.batch_id]:
+                del self.running_tasks[task.batch_id]
 
     def _clear_timeout_tasks(self, batch_id: Union[int, str]) -> None:
         if batch_id in self.pending_tasks:
@@ -280,8 +290,30 @@ class Scheduler:
         """
         if not tasks:
             return
-        for task in tasks:
-            self.pending_tasks[batch_id].appendleft(task)
+        self._split_and_submit_tasks(tasks, batch_id=batch_id)
+
+    def _split_and_submit_tasks(self, tasks: List[Task], batch_id: Union[int, str]) -> None:
+        for i, task in enumerate(tasks):
+            group_id = f"{batch_id}/{i}"
+            task.group_id = group_id
+            if self.max_repeat_times is None:
+                self.pending_tasks[batch_id].appendleft(
+                    TaskWrapper(
+                        task=task,
+                        batch_id=batch_id,
+                        repeat_times=task.rollout_args.n,
+                    )
+                )
+                continue
+            rest_repeat_times = task.rollout_args.n
+            while rest_repeat_times > 0:
+                task_wrapper = TaskWrapper(
+                    task=task,
+                    batch_id=batch_id,
+                    repeat_times=min(self.max_repeat_times, rest_repeat_times),
+                )
+                rest_repeat_times -= task_wrapper.repeat_times
+                self.pending_tasks[batch_id].appendleft(task_wrapper)
 
     async def get_results(
         self,
@@ -322,7 +354,7 @@ class Scheduler:
             if clear_timeout_tasks:
                 self._clear_timeout_tasks(batch_id=batch_id)
                 for runner_id in list(self.busy_runners.keys()):
-                    if self.busy_runners[runner_id][1] == batch_id:
+                    if self.busy_runners[runner_id].batch_id == batch_id:
                         self._restart_runner(runner_id)
 
         results = []

--- a/trinity/explorer/scheduler.py
+++ b/trinity/explorer/scheduler.py
@@ -134,7 +134,7 @@ class Scheduler:
         self.namespace = ray.get_runtime_context().namespace
         self.default_timeout = config.explorer.max_timeout * (config.explorer.max_retry_times + 1)
         self.max_retry_times = config.explorer.max_retry_times
-        self.max_repeat_times = config.explorer.max_repeat_times
+        self.max_repeat_times = config.explorer.max_repeat_times_per_runner
         self.running = False
 
         self.runner_num = len(rollout_model) * config.explorer.runner_per_model

--- a/trinity/explorer/workflow_runner.py
+++ b/trinity/explorer/workflow_runner.py
@@ -2,7 +2,6 @@
 """The Workflow Runner Moudle."""
 import time
 import traceback
-import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Optional
@@ -78,10 +77,9 @@ class WorkflowRunner:
             exps = self._run_task(task)
             assert exps is not None and len(exps) > 0, "An empty experience is generated"
             metrics: dict[str, List[float]] = defaultdict(list)
-            # add run_id
-            run_id = str(uuid.uuid4())
+            # set group id
             for exp in exps:
-                setattr(exp, "run_id", run_id)
+                setattr(exp, "group_id", task.group_id)
 
                 if not hasattr(exp, "info") or exp.info is None:
                     exp.info = {}


### PR DESCRIPTION
## Description

Add `explorer.max_repeat_times`, which limits the number of times a single runner can repeat a task, thereby splitting tasks with larger `repeat_times` into multiple subtasks to be executed on different runners. When `explorer.max_repeat_times` is not set, no splitting will be performed.

This method can reduce the overall latency of tasks with large `repeat_times` and lower the cost of failed retries; however, it will also cause the rollout results of the same group to be scattered. Users must decide whether to enable this function based on their actual needs.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review
