### PR TITLE
Auto-set pad_token_id when the default is None and not set in the buffer config.

### DIFF
--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -7,7 +7,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from omegaconf import OmegaConf
-from verl.utils.tokenizer import set_pad_token_id
 
 from trinity.common.constants import (
     EXPLORER_NAME,
@@ -670,7 +669,18 @@ class Config:
 
             try:
                 tokenizer = AutoTokenizer.from_pretrained(self.model.model_path)
-                set_pad_token_id(tokenizer)
+                if tokenizer.pad_token_id is None:
+                    tokenizer.pad_token_id = tokenizer.eos_token_id
+                    logger.warning(
+                        f"tokenizer.pad_token_id is None. Now set to {tokenizer.eos_token_id}",
+                        stacklevel=1,
+                    )
+                if tokenizer.pad_token is None:
+                    tokenizer.pad_token = tokenizer.eos_token
+                    logger.warning(
+                        f"tokenizer.pad_token is None. Now set to {tokenizer.eos_token}",
+                        stacklevel=1,
+                    )
                 self.buffer.pad_token_id = tokenizer.pad_token_id
 
             except Exception:

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -675,12 +675,6 @@ class Config:
                         f"tokenizer.pad_token_id is None. Now set to {tokenizer.eos_token_id}",
                         stacklevel=1,
                     )
-                if tokenizer.pad_token is None:
-                    tokenizer.pad_token = tokenizer.eos_token
-                    logger.warning(
-                        f"tokenizer.pad_token is None. Now set to {tokenizer.eos_token}",
-                        stacklevel=1,
-                    )
                 self.buffer.pad_token_id = tokenizer.pad_token_id
 
             except Exception:

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from omegaconf import OmegaConf
+from verl.utils import set_pad_token_id
 
 from trinity.common.constants import (
     EXPLORER_NAME,
@@ -668,9 +669,10 @@ class Config:
             from transformers import AutoTokenizer
 
             try:
-                self.buffer.pad_token_id = AutoTokenizer.from_pretrained(
-                    self.model.model_path
-                ).pad_token_id
+                tokenizer = AutoTokenizer.from_pretrained(self.model.model_path)
+                set_pad_token_id(tokenizer)
+                self.buffer.pad_token_id = tokenizer.pad_token_id
+
             except Exception:
                 logger.warning(f"Failed to get pad token id from model {self.model.model_path}")
                 self.buffer.pad_token_id = 0

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from omegaconf import OmegaConf
-from verl.utils import set_pad_token_id
+from verl.utils.tokenizer import set_pad_token_id
 
 from trinity.common.constants import (
     EXPLORER_NAME,

--- a/trinity/trainer/verl_trainer.py
+++ b/trinity/trainer/verl_trainer.py
@@ -38,8 +38,6 @@ from trinity.trainer.trainer import TrainEngineWrapper
 from trinity.trainer.verl.utils import compute_data_metrics, to_data_proto
 from trinity.utils.log import get_logger
 
-logger = get_logger(__name__)
-
 
 class _InternalDataLoader:
     def __init__(self, config):
@@ -84,13 +82,6 @@ class VerlPPOTrainerWrapper(RayPPOTrainer, TrainEngineWrapper):
         # instantiate tokenizer
 
         tokenizer = hf_tokenizer(local_path)
-
-        # overide the pad_token_id in config
-        if global_config.buffer.pad_token_id is None:
-            global_config.buffer.pad_token_id = tokenizer.pad_token_id
-            logger.warning(
-                f"pad_token_id is not set, using {global_config.buffer.pad_token_id} as pad_token_id"
-            )
 
         # define worker classes
         if config.actor_rollout_ref.actor.strategy == "fsdp":

--- a/trinity/trainer/verl_trainer.py
+++ b/trinity/trainer/verl_trainer.py
@@ -38,6 +38,7 @@ from trinity.trainer.trainer import TrainEngineWrapper
 from trinity.trainer.verl.utils import compute_data_metrics, to_data_proto
 from trinity.utils.log import get_logger
 
+logger = get_logger(__name__)
 
 class _InternalDataLoader:
     def __init__(self, config):
@@ -82,6 +83,11 @@ class VerlPPOTrainerWrapper(RayPPOTrainer, TrainEngineWrapper):
         # instantiate tokenizer
 
         tokenizer = hf_tokenizer(local_path)
+
+        # overide the pad_token_id in config
+        if global_config.buffer.pad_token_id is None:
+            global_config.buffer.pad_token_id = tokenizer.pad_token_id
+            logger.warning(f"pad_token_id is not set, using {global_config.buffer.pad_token_id} as pad_token_id")
 
         # define worker classes
         if config.actor_rollout_ref.actor.strategy == "fsdp":

--- a/trinity/trainer/verl_trainer.py
+++ b/trinity/trainer/verl_trainer.py
@@ -40,6 +40,7 @@ from trinity.utils.log import get_logger
 
 logger = get_logger(__name__)
 
+
 class _InternalDataLoader:
     def __init__(self, config):
         self.config = config
@@ -87,7 +88,9 @@ class VerlPPOTrainerWrapper(RayPPOTrainer, TrainEngineWrapper):
         # overide the pad_token_id in config
         if global_config.buffer.pad_token_id is None:
             global_config.buffer.pad_token_id = tokenizer.pad_token_id
-            logger.warning(f"pad_token_id is not set, using {global_config.buffer.pad_token_id} as pad_token_id")
+            logger.warning(
+                f"pad_token_id is not set, using {global_config.buffer.pad_token_id} as pad_token_id"
+            )
 
         # define worker classes
         if config.actor_rollout_ref.actor.strategy == "fsdp":


### PR DESCRIPTION
## Description

**Background:** 
When using models like Llama where the default `pad_token_id` is `None`, the sampler_strategy could be incorrect if `pad_token_id` wasn't explicitly set in the config. Both Verl and vLLM automatically handle this during tokenizer loading by setting appropriate `pad_token_id` values.

**Purpose:** 
Update the config after tokenizer loading to ensure the `pad_token_id` is properly set, making the sampler_strategy consistent and correct.

**Changes made:**
- Added config update logic after tokenizer loading to set `pad_token_id` when it's `None` in the original config
- Ensures sampler_strategy uses the correct `pad_token_id` that Verl/vLLM have automatically determined during tokenizer initialization
- Maintains alignment between our config and the actual tokenizer configuration

**How to test:**
1. Load a Llama tokenizer without specifying `pad_token_id` in the initial config
2. Verify that after tokenizer loading, the config is updated with the correct `pad_token_id`
3. Confirm that sampler_strategy works correctly with the updated config
4. Test with tokenizers that already have explicit `pad_token_id` to ensure no regression

## Checklist
Please check the following items before code is ready to be reviewed.
- [x ]  Code has passed all tests
- [x ]  Docstrings have been added/updated in Google Style
- [x ]  Code is ready for review
