### PR TITLE
Set truncate_prompt_tokens in SamplingParams, silently truncating very large prompts and preventing vllm from throwing exception

### DIFF
--- a/trinity/common/models/vllm_model.py
+++ b/trinity/common/models/vllm_model.py
@@ -53,6 +53,7 @@ class vLLMRolloutModel(InferenceModel):
             temperature=0.0,
             max_tokens=config.max_response_tokens,
             min_tokens=1,
+            truncate_prompt_tokens=config.max_model_len-1,
             skip_special_tokens=True,
             include_stop_str_in_output=False,
             output_kind=RequestOutputKind.FINAL_ONLY,

--- a/trinity/common/models/vllm_model.py
+++ b/trinity/common/models/vllm_model.py
@@ -53,7 +53,7 @@ class vLLMRolloutModel(InferenceModel):
             temperature=0.0,
             max_tokens=config.max_response_tokens,
             min_tokens=1,
-            truncate_prompt_tokens=config.max_model_len-1,
+            truncate_prompt_tokens=config.max_model_len - 1,
             skip_special_tokens=True,
             include_stop_str_in_output=False,
             output_kind=RequestOutputKind.FINAL_ONLY,

--- a/trinity/common/models/vllm_model.py
+++ b/trinity/common/models/vllm_model.py
@@ -53,7 +53,7 @@ class vLLMRolloutModel(InferenceModel):
             temperature=0.0,
             max_tokens=config.max_response_tokens,
             min_tokens=1,
-            truncate_prompt_tokens=config.max_model_len - 1,
+            truncate_prompt_tokens=config.max_model_len - 1,  # type: ignore [operator]
             skip_special_tokens=True,
             include_stop_str_in_output=False,
             output_kind=RequestOutputKind.FINAL_ONLY,


### PR DESCRIPTION
Partially fixing:
- https://github.com/modelscope/Trinity-RFT/issues/197

---

To prevent vllm throwing exceptions like:
`ERROR 08-17 23:32:15 scheduler.py:86] ValueError: The decoder prompt (length 42861) is longer than the maximum model length of 32768. Make sure that max_model_len is no smaller than the number of text tokens.`

`truncate_prompt_tokens=config.max_model_len-1` is used to ensure at least one output token

A similar setting was used before https://github.com/modelscope/Trinity-RFT/pull/172, and got removed without an explanation that I could find

## Description

[Please describe the background, purpose, changes made, and how to test this PR]


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
