### PR TITLE
Support new task ordering methods

### DIFF
--- a/trinity/service/data_juicer/server/session.py
+++ b/trinity/service/data_juicer/server/session.py
@@ -13,8 +13,6 @@ from trinity.service.data_juicer.server.utils import (
 )
 from trinity.utils.log import get_logger
 
-logger = get_logger(__name__)
-
 
 def extract_metrics(dataset: Dataset) -> Dict:
     """Extract metrics from the processed dataset."""
@@ -46,6 +44,8 @@ class DataJuicerSession:
         self.order_args = self.config.order_args or {
             "folding_layers": 3,
         }
+
+        self.logger = get_logger(__name__)
 
     def process_experience(self, ds: Dataset) -> Tuple[Dataset, Dict]:
         """Process a batch of experiences.
@@ -92,7 +92,7 @@ class DataJuicerSession:
         """
         # check if priority field exists
         if "priority" not in dataset.features and self.order_method in {"sort", "folding"}:
-            logger.warning(
+            self.logger.warning(
                 f'"priority" field not found for {self.order_method}. Use "keep" instead.'
             )
             self.order_method = "keep"

--- a/trinity/service/data_juicer/server/utils.py
+++ b/trinity/service/data_juicer/server/utils.py
@@ -24,6 +24,8 @@ class DJConfig(BaseModel):
     target_fields: List[str] = []  # fields in the output dataset
     priority_weights: Dict[str, float] = {}  # weights for priority computing
     top_k: int = -1  # number of samples to select after task pipeline. -1 means all
+    order_method: Literal["keep", "shuffle", "sort", "folding"] = "sort"
+    order_args: Dict = {}
 
     @model_validator(mode="after")
     def check_dj_config(self):


### PR DESCRIPTION
## Description

Support 4 task ordering methods:
- keep: keep the original order.
- shuffle: randomly shuffle the task order.
- sort: sort the tasks according to their priority score.
- folding: folding the tasks into L layers after they are sorted. Ref: https://arxiv.org/abs/2506.21545


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review
