### PR TITLE
Explorer provides OpenAI API compatible inference service

### DIFF
--- a/examples/grpo_gsm8k/gsm8k.yaml
+++ b/examples/grpo_gsm8k/gsm8k.yaml
@@ -72,3 +72,16 @@ trainer:
         log_prob_use_dynamic_bsz: ${trainer.trainer_config.actor_rollout_ref.actor.use_dynamic_bsz}
         log_prob_max_token_len_per_gpu: ${trainer.trainer_config.actor_rollout_ref.actor.ppo_max_token_len_per_gpu}
         ulysses_sequence_parallel_size: ${trainer.trainer_config.actor_rollout_ref.actor.ulysses_sequence_parallel_size} # sp size
+# stages:  # Uncomment to add a SFT warmup stage before RFT
+#   - stage_name: sft_warmup
+#     mode: train
+#     algorithm:
+#       algorithm_type: sft
+#     buffer:
+#       train_batch_size: 128
+#       total_steps: 10
+#       trainer_input:
+#         experience_buffer:
+#           name: sft_warmup_dataset
+#           path: ${oc.env:TRINITY_SFT_DATASET_PATH}
+#   - stage_name: rft  # leave empty to use the original configs for RFT

--- a/examples/mix_chord/mix_chord.yaml
+++ b/examples/mix_chord/mix_chord.yaml
@@ -58,6 +58,7 @@ buffer:
         total_epochs: 25
         name: SFT_data
         storage_type: file
+        schema_type: sft
         path: ${oc.env:TRINITY_SFT_DATASET_PATH,open-r1/Mixture-of-Thoughts}
         split: 'train'
         format:

--- a/examples/mix_math/mix_math.yaml
+++ b/examples/mix_math/mix_math.yaml
@@ -58,6 +58,7 @@ buffer:
         total_epochs: 10
         name: math_sft
         storage_type: file
+        schema_type: sft
         path: ${oc.env:TRINITY_SFT_DATASET_PATH,open-r1/Mixture-of-Thoughts}
         split: 'train'
         format:

--- a/tests/cli/launcher_test.py
+++ b/tests/cli/launcher_test.py
@@ -38,7 +38,9 @@ class TestLauncherMain(unittest.TestCase):
     @mock.patch("trinity.cli.launcher.both")
     @mock.patch("trinity.cli.launcher.bench")
     @mock.patch("trinity.cli.launcher.load_config")
-    def test_main_run_command(self, mock_load, mock_bench, mock_both, mock_train, mock_explore, mock_serve):
+    def test_main_run_command(
+        self, mock_load, mock_bench, mock_both, mock_train, mock_explore, mock_serve
+    ):
         config = get_template_config()
         mapping = {
             "explore": mock_explore,
@@ -47,13 +49,16 @@ class TestLauncherMain(unittest.TestCase):
             "bench": mock_bench,
             "serve": mock_serve,
         }
-        with mock.patch.dict(launcher.MODE_MAP, {
-            "explore": mock_explore,
-            "train": mock_train,
-            "both": mock_both,
-            "bench": mock_bench,
-            "serve": mock_serve,
-        }):
+        with mock.patch.dict(
+            launcher.MODE_MAP,
+            {
+                "explore": mock_explore,
+                "train": mock_train,
+                "both": mock_both,
+                "bench": mock_bench,
+                "serve": mock_serve,
+            },
+        ):
             for mode in ["explore", "train", "both", "bench", "serve"]:
                 config.mode = mode
                 mock_load.return_value = config
@@ -82,9 +87,12 @@ class TestLauncherMain(unittest.TestCase):
         config.log.group_by_node = True
         mock_setup.return_value = "auto"
         mock_load.return_value = config
-        with mock.patch.dict(launcher.MODE_MAP, {
-            "both": mock_both,
-        }):
+        with mock.patch.dict(
+            launcher.MODE_MAP,
+            {
+                "both": mock_both,
+            },
+        ):
             with mock.patch(
                 "argparse.ArgumentParser.parse_args",
                 return_value=mock.Mock(
@@ -168,10 +176,13 @@ class TestLauncherMain(unittest.TestCase):
         ]
         mock_load.return_value = config
         mock_checkpoint_path.return_value = "/path/to/hf/checkpoint"
-        with mock.patch.dict(launcher.MODE_MAP, {
-            "train": mock_train,
-            "both": mock_both,
-        }):
+        with mock.patch.dict(
+            launcher.MODE_MAP,
+            {
+                "train": mock_train,
+                "both": mock_both,
+            },
+        ):
             with mock.patch(
                 "argparse.ArgumentParser.parse_args",
                 return_value=mock.Mock(
@@ -210,7 +221,10 @@ class TestLauncherMain(unittest.TestCase):
                         "env_vars": {
                             launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
                             launcher.LOG_DIR_ENV_VAR: os.path.join(
-                                config.checkpoint_root_dir, config.project, f"{config.name}/grpo", "log"
+                                config.checkpoint_root_dir,
+                                config.project,
+                                f"{config.name}/grpo",
+                                "log",
                             ),
                             launcher.LOG_LEVEL_ENV_VAR: config.log.level,
                             launcher.LOG_NODE_IP_ENV_VAR: "0",

--- a/tests/cli/launcher_test.py
+++ b/tests/cli/launcher_test.py
@@ -32,33 +32,42 @@ class TestLauncherMain(unittest.TestCase):
     def tearDown(self):
         sys.argv = self._orig_argv
 
+    @mock.patch("trinity.cli.launcher.serve")
     @mock.patch("trinity.cli.launcher.explore")
     @mock.patch("trinity.cli.launcher.train")
     @mock.patch("trinity.cli.launcher.both")
     @mock.patch("trinity.cli.launcher.bench")
     @mock.patch("trinity.cli.launcher.load_config")
-    def test_main_run_command(self, mock_load, mock_bench, mock_both, mock_train, mock_explore):
+    def test_main_run_command(self, mock_load, mock_bench, mock_both, mock_train, mock_explore, mock_serve):
         config = get_template_config()
         mapping = {
             "explore": mock_explore,
             "train": mock_train,
             "both": mock_both,
             "bench": mock_bench,
+            "serve": mock_serve,
         }
-        for mode in ["explore", "train", "both", "bench"]:
-            config.mode = mode
-            mock_load.return_value = config
-            with mock.patch(
-                "argparse.ArgumentParser.parse_args",
-                return_value=mock.Mock(
-                    command="run", config="dummy.yaml", dlc=False, plugin_dir=None
-                ),
-            ):
-                launcher.main()
-            mock_load.assert_called_once_with("dummy.yaml")
-            mapping[mode].assert_called_once_with(config)
-            mock_load.reset_mock()
-            mapping[mode].reset_mock()
+        with mock.patch.dict(launcher.MODE_MAP, {
+            "explore": mock_explore,
+            "train": mock_train,
+            "both": mock_both,
+            "bench": mock_bench,
+            "serve": mock_serve,
+        }):
+            for mode in ["explore", "train", "both", "bench", "serve"]:
+                config.mode = mode
+                mock_load.return_value = config
+                with mock.patch(
+                    "argparse.ArgumentParser.parse_args",
+                    return_value=mock.Mock(
+                        command="run", config="dummy.yaml", dlc=False, plugin_dir=None
+                    ),
+                ):
+                    launcher.main()
+                mock_load.assert_called_once_with("dummy.yaml")
+                mapping[mode].assert_called_once_with(config)
+                mock_load.reset_mock()
+                mapping[mode].reset_mock()
 
     @mock.patch("trinity.cli.launcher.stop_ray_cluster")
     @mock.patch("trinity.cli.launcher.setup_ray_cluster")
@@ -73,35 +82,38 @@ class TestLauncherMain(unittest.TestCase):
         config.log.group_by_node = True
         mock_setup.return_value = "auto"
         mock_load.return_value = config
-        with mock.patch(
-            "argparse.ArgumentParser.parse_args",
-            return_value=mock.Mock(
-                command="run", config="dummy.yaml", dlc=True, plugin_dir="/path/to/plugins"
-            ),
-        ):
-            launcher.main()
-        mock_init.assert_called_once()
-        mock_init.assert_called_once_with(
-            address="auto",
-            ignore_reinit_error=True,
-            namespace=config.ray_namespace,
-            runtime_env={
-                "env_vars": {
-                    launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
-                    launcher.LOG_DIR_ENV_VAR: config.log.save_dir,
-                    launcher.LOG_LEVEL_ENV_VAR: config.log.level,
-                    launcher.LOG_NODE_IP_ENV_VAR: "1",
-                }
-            },
-        )
-        mock_load.assert_called_once_with("dummy.yaml")
-        mock_both.assert_called_once_with(config)
-        mock_setup.assert_called_once_with(
-            namespace=namespace,
-        )
-        mock_stop.assert_called_once_with(
-            namespace=namespace,
-        )
+        with mock.patch.dict(launcher.MODE_MAP, {
+            "both": mock_both,
+        }):
+            with mock.patch(
+                "argparse.ArgumentParser.parse_args",
+                return_value=mock.Mock(
+                    command="run", config="dummy.yaml", dlc=True, plugin_dir="/path/to/plugins"
+                ),
+            ):
+                launcher.main()
+            mock_init.assert_called_once()
+            mock_init.assert_called_once_with(
+                address="auto",
+                ignore_reinit_error=True,
+                namespace=config.ray_namespace,
+                runtime_env={
+                    "env_vars": {
+                        launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
+                        launcher.LOG_DIR_ENV_VAR: config.log.save_dir,
+                        launcher.LOG_LEVEL_ENV_VAR: config.log.level,
+                        launcher.LOG_NODE_IP_ENV_VAR: "1",
+                    }
+                },
+            )
+            mock_load.assert_called_once_with("dummy.yaml")
+            mock_both.assert_called_once_with(config)
+            mock_setup.assert_called_once_with(
+                namespace=namespace,
+            )
+            mock_stop.assert_called_once_with(
+                namespace=namespace,
+            )
 
     @mock.patch("trinity.cli.launcher.studio")
     def test_main_studio_command(self, mock_studio):
@@ -156,60 +168,64 @@ class TestLauncherMain(unittest.TestCase):
         ]
         mock_load.return_value = config
         mock_checkpoint_path.return_value = "/path/to/hf/checkpoint"
-        with mock.patch(
-            "argparse.ArgumentParser.parse_args",
-            return_value=mock.Mock(
-                command="run", config="dummy.yaml", dlc=False, plugin_dir="/path/to/plugins"
-            ),
-        ):
-            launcher.main()
-        self.assertEqual(mock_init.call_count, 2)
-        self.assertEqual(mock_shutdown.call_count, 2)
-        mock_train.assert_called_once()
-        mock_both.assert_called_once()
-        expected_calls = [
-            mock.call(
-                address="auto",
-                ignore_reinit_error=True,
-                namespace=f"{config.project}/{config.name}/sft_warmup",
-                runtime_env={
-                    "env_vars": {
-                        launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
-                        launcher.LOG_DIR_ENV_VAR: os.path.join(
-                            config.checkpoint_root_dir,
-                            config.project,
-                            f"{config.name}/sft_warmup",
-                            "log",
-                        ),
-                        launcher.LOG_LEVEL_ENV_VAR: config.log.level,
-                        launcher.LOG_NODE_IP_ENV_VAR: "0",
-                    }
-                },
-            ),
-            mock.call(
-                address="auto",
-                ignore_reinit_error=True,
-                namespace=f"{config.project}/{config.name}/grpo",
-                runtime_env={
-                    "env_vars": {
-                        launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
-                        launcher.LOG_DIR_ENV_VAR: os.path.join(
-                            config.checkpoint_root_dir, config.project, f"{config.name}/grpo", "log"
-                        ),
-                        launcher.LOG_LEVEL_ENV_VAR: config.log.level,
-                        launcher.LOG_NODE_IP_ENV_VAR: "0",
-                    }
-                },
-            ),
-        ]
-        mock_init.assert_has_calls(expected_calls)
-        self.assertEqual(mock_checkpoint_path.call_count, 2)
-        self.assertEqual(mock_train.call_args[0][0].model.model_path, config.model.model_path)
-        self.assertEqual(mock_both.call_args[0][0].model.model_path, "/path/to/hf/checkpoint")
-        self.assertEqual(
-            mock_both.call_args[0][0].trainer.trainer_config.actor_rollout_ref.model.path,
-            "/path/to/hf/checkpoint",
-        )
+        with mock.patch.dict(launcher.MODE_MAP, {
+            "train": mock_train,
+            "both": mock_both,
+        }):
+            with mock.patch(
+                "argparse.ArgumentParser.parse_args",
+                return_value=mock.Mock(
+                    command="run", config="dummy.yaml", dlc=False, plugin_dir="/path/to/plugins"
+                ),
+            ):
+                launcher.main()
+            self.assertEqual(mock_init.call_count, 2)
+            self.assertEqual(mock_shutdown.call_count, 2)
+            mock_train.assert_called_once()
+            mock_both.assert_called_once()
+            expected_calls = [
+                mock.call(
+                    address="auto",
+                    ignore_reinit_error=True,
+                    namespace=f"{config.project}/{config.name}/sft_warmup",
+                    runtime_env={
+                        "env_vars": {
+                            launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
+                            launcher.LOG_DIR_ENV_VAR: os.path.join(
+                                config.checkpoint_root_dir,
+                                config.project,
+                                f"{config.name}/sft_warmup",
+                                "log",
+                            ),
+                            launcher.LOG_LEVEL_ENV_VAR: config.log.level,
+                            launcher.LOG_NODE_IP_ENV_VAR: "0",
+                        }
+                    },
+                ),
+                mock.call(
+                    address="auto",
+                    ignore_reinit_error=True,
+                    namespace=f"{config.project}/{config.name}/grpo",
+                    runtime_env={
+                        "env_vars": {
+                            launcher.PLUGIN_DIRS_ENV_VAR: "/path/to/plugins",
+                            launcher.LOG_DIR_ENV_VAR: os.path.join(
+                                config.checkpoint_root_dir, config.project, f"{config.name}/grpo", "log"
+                            ),
+                            launcher.LOG_LEVEL_ENV_VAR: config.log.level,
+                            launcher.LOG_NODE_IP_ENV_VAR: "0",
+                        }
+                    },
+                ),
+            ]
+            mock_init.assert_has_calls(expected_calls)
+            self.assertEqual(mock_checkpoint_path.call_count, 2)
+            self.assertEqual(mock_train.call_args[0][0].model.model_path, config.model.model_path)
+            self.assertEqual(mock_both.call_args[0][0].model.model_path, "/path/to/hf/checkpoint")
+            self.assertEqual(
+                mock_both.call_args[0][0].trainer.trainer_config.actor_rollout_ref.model.path,
+                "/path/to/hf/checkpoint",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/common/vllm_test.py
+++ b/tests/common/vllm_test.py
@@ -127,6 +127,7 @@ class ModelWrapperTest(RayUnittestBaseAysnc):
     async def test_generate(
         self,
     ):
+        await self.model_wrapper.prepare()
         prompts = ["Hello, world!", "Hello, my name is"]
         n = self.config.algorithm.repeat_times
         if self.use_async:
@@ -272,7 +273,7 @@ class TestModelLen(RayUnittestBase):
         self.assertEqual(len(exps[0].tokens), self.max_model_len)
 
 
-class TestAPIServer(RayUnittestBase):
+class TestAPIServer(RayUnittestBaseAysnc):
     def setUp(self):
         self.config = get_template_config()
         self.config.mode = "explore"
@@ -291,7 +292,9 @@ class TestAPIServer(RayUnittestBase):
             self.engines[0], engine_type="vllm", enable_history=False
         )
 
-    def test_api(self):
+    async def test_api(self):
+        await self.model_wrapper.prepare()
+        await self.model_wrapper_no_history.prepare()
         openai_client = self.model_wrapper.get_openai_client()
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -361,6 +364,8 @@ class TestAsyncAPIServer(RayUnittestBaseAysnc):
         )
 
     async def test_api_async(self):
+        await self.model_wrapper.prepare()
+        await self.model_wrapper_no_history.prepare()
         openai_client = self.model_wrapper.get_openai_async_client()
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -528,7 +533,7 @@ class TestTokenizer(unittest.TestCase):
         (False, None),
     ],
 )
-class TestAPIServerToolCall(RayUnittestBase):
+class TestAPIServerToolCall(RayUnittestBaseAysnc):
     def setUp(self):
         self.config = get_template_config()
         self.config.mode = "explore"
@@ -552,13 +557,15 @@ class TestAPIServerToolCall(RayUnittestBase):
             self.engines[0], engine_type="vllm", enable_history=False
         )
 
-    def test_api_tool_calls(self):
+    async def test_api_tool_calls(self):
         """Tests the full conversation flow of a tool call via the OpenAI API.
         Note: This test require a model that supports tool calls and thinking mode, e.g. Qwen3-1.7B.
         """
         import json
         import time
 
+        await self.model_wrapper.prepare()
+        await self.model_wrapper_no_history.prepare()
         tokenizer = AutoTokenizer.from_pretrained(get_api_model_path())
         print_debug("\n\n" + "=" * 30 + " Running test_api_tool_calls " + "=" * 30)
         start_time = time.time()

--- a/tests/common/vllm_test.py
+++ b/tests/common/vllm_test.py
@@ -6,7 +6,6 @@ from parameterized import parameterized_class
 from transformers import AutoTokenizer
 
 from tests.tools import (
-    RayUnittestBase,
     RayUnittestBaseAysnc,
     get_api_model_path,
     get_model_path,
@@ -229,7 +228,7 @@ class ModelWrapperTest(RayUnittestBaseAysnc):
         (20, None, 1),
     ],
 )
-class TestModelLen(RayUnittestBase):
+class TestModelLen(RayUnittestBaseAysnc):
     def setUp(self):
         self.config = get_template_config()
         self.config.mode = "explore"
@@ -243,7 +242,8 @@ class TestModelLen(RayUnittestBase):
         self.engines, self.auxiliary_engines = create_inference_models(self.config)
         self.model_wrapper = ModelWrapper(self.engines[0], engine_type="vllm", enable_history=True)
 
-    def test_model_len(self):
+    async def test_model_len(self):
+        await self.model_wrapper.prepare()
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "What's the weather like today?"},

--- a/tests/explorer/scheduler_test.py
+++ b/tests/explorer/scheduler_test.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 import unittest
-from typing import List
+from typing import List, Optional
 
 import ray
 import torch
@@ -147,6 +147,12 @@ class DummyModel(InferenceModel):
     ) -> None:
         pass
 
+    def has_api_server(self) -> bool:
+        return False
+
+    def get_api_server_url(self) -> Optional[str]:
+        return None
+
 
 @ray.remote
 class DummyAuxiliaryModel(InferenceModel):
@@ -171,8 +177,8 @@ class DummyAuxiliaryModel(InferenceModel):
     def has_api_server(self) -> bool:
         return True
 
-    def api_server_ready(self) -> str:
-        return "http://localhosts:12345"
+    def get_api_server_url(self) -> str:
+        return "http://localhost:12345"
 
 
 def generate_tasks(

--- a/tests/trainer/trainer_test.py
+++ b/tests/trainer/trainer_test.py
@@ -720,3 +720,7 @@ class TestTrainerMultiModal(BaseTrainerCase):
         )
         self.assertTrue(len(os.listdir(os.path.join(checkpoint_step_2, "actor"))) > 0)
         self.assertEqual(step_num, 2)
+
+    def tearDown(self):
+        # remove dir only when the test passed
+        shutil.rmtree(self.config.checkpoint_job_dir)

--- a/trinity/algorithm/sample_strategy/mix_sample_strategy.py
+++ b/trinity/algorithm/sample_strategy/mix_sample_strategy.py
@@ -38,6 +38,18 @@ class MixSampleStrategy(SampleStrategy):
                 "`buffer_config.trainer_input.auxiliary_buffers` is required in MIX algorithm"
             )
 
+        if buffer_config.trainer_input.auxiliary_buffers.get(self.sft_dataset_name) is None:
+            raise ValueError(
+                f"`{self.sft_dataset_name}` is not found in `buffer_config.trainer_input.auxiliary_buffers`"
+            )
+        expert_storage_config = buffer_config.trainer_input.auxiliary_buffers[self.sft_dataset_name]
+
+        if expert_storage_config.schema_type != "sft":
+            self.logger.warning(
+                f"schema_type of {self.sft_dataset_name} is not `sft`, set it to `sft`"
+            )
+            expert_storage_config.schema_type = "sft"
+
         # expert experience buffer
         expert_buffer_config = copy.deepcopy(buffer_config)
         expert_buffer_config.train_batch_size = expert_batch_size

--- a/trinity/buffer/pipelines/experience_pipeline.py
+++ b/trinity/buffer/pipelines/experience_pipeline.py
@@ -1,6 +1,6 @@
 import traceback
 from queue import Queue
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from trinity.buffer.buffer import BufferWriter, get_buffer_reader, get_buffer_writer
 from trinity.buffer.operators.experience_operator import ExperienceOperator
@@ -117,12 +117,6 @@ class ExperiencePipeline:
         if self.input_store is not None:
             await self.input_store.write_async(exps)
 
-        if exps is None or len(exps) == 0:
-            # get all experiences from the queue
-            exps = []
-            while not self.queue.empty():
-                exps.append(self.queue.get())
-
         metrics = {}
 
         # Process experiences through operators
@@ -142,20 +136,6 @@ class ExperiencePipeline:
                 result_metrics[f"pipeline/{key}"] = float(value)
 
         return result_metrics
-
-    async def write(self, exps: Union[Experience, List[Experience]]) -> None:
-        """Write experiences to the pipeline and prepare for processing.
-
-        Args:
-            exps (Union[Experience, List[Experience]]): A single experience or a list of experiences to process.
-        """
-        if not isinstance(exps, list):
-            exps = [exps]
-        for exp in exps:
-            self.queue.put(exp)
-
-        if self.input_store is not None:
-            await self.input_store.write_async(exps)
 
     async def close(self) -> None:
         try:

--- a/trinity/buffer/pipelines/experience_pipeline.py
+++ b/trinity/buffer/pipelines/experience_pipeline.py
@@ -1,5 +1,4 @@
 import traceback
-from queue import Queue
 from typing import Dict, List, Optional
 
 from trinity.buffer.buffer import BufferWriter, get_buffer_reader, get_buffer_writer
@@ -50,7 +49,6 @@ class ExperiencePipeline:
             buffer_config.trainer_input.experience_buffer,  # type: ignore [arg-type]
             buffer_config,
         )
-        self.queue = Queue()
 
     def _init_input_storage(
         self,

--- a/trinity/buffer/pipelines/experience_pipeline.py
+++ b/trinity/buffer/pipelines/experience_pipeline.py
@@ -1,5 +1,6 @@
 import traceback
-from typing import Dict, List, Optional
+from queue import Queue
+from typing import Dict, List, Optional, Union
 
 from trinity.buffer.buffer import BufferWriter, get_buffer_reader, get_buffer_writer
 from trinity.buffer.operators.experience_operator import ExperienceOperator
@@ -49,6 +50,7 @@ class ExperiencePipeline:
             buffer_config.trainer_input.experience_buffer,  # type: ignore [arg-type]
             buffer_config,
         )
+        self.queue = Queue()
 
     def _init_input_storage(
         self,
@@ -114,6 +116,13 @@ class ExperiencePipeline:
         """
         if self.input_store is not None:
             await self.input_store.write_async(exps)
+
+        if exps is None or len(exps) == 0:
+            # get all experiences from the queue
+            exps = []
+            while not self.queue.empty():
+                exps.append(self.queue.get())
+
         metrics = {}
 
         # Process experiences through operators
@@ -133,6 +142,20 @@ class ExperiencePipeline:
                 result_metrics[f"pipeline/{key}"] = float(value)
 
         return result_metrics
+
+    async def write(self, exps: Union[Experience, List[Experience]]) -> None:
+        """Write experiences to the pipeline and prepare for processing.
+
+        Args:
+            exps (Union[Experience, List[Experience]]): A single experience or a list of experiences to process.
+        """
+        if not isinstance(exps, list):
+            exps = [exps]
+        for exp in exps:
+            self.queue.put(exp)
+
+        if self.input_store is not None:
+            await self.input_store.write_async(exps)
 
     async def close(self) -> None:
         try:

--- a/trinity/buffer/storage/sql.py
+++ b/trinity/buffer/storage/sql.py
@@ -32,7 +32,7 @@ class SQLStorage:
 
     def __init__(self, storage_config: StorageConfig, config: BufferConfig) -> None:
         self.logger = get_logger(f"sql_{storage_config.name}", in_ray_actor=True)
-        if storage_config.path is None:
+        if not storage_config.path:
             storage_config.path = default_storage_path(storage_config, config)
         self.engine, self.table_model_cls = init_engine(
             db_url=storage_config.path,

--- a/trinity/cli/launcher.py
+++ b/trinity/cli/launcher.py
@@ -68,6 +68,7 @@ def serve(config: Config) -> None:
     try:
         explorer = Explorer.get_actor(config)
         ray.get(explorer.prepare.remote())
+        ray.get(explorer.sync_weight.remote())
         ray.get(explorer.serve.remote())
         ray.get(explorer.shutdown.remote())
     except Exception:
@@ -160,6 +161,8 @@ def run_stage(config: Config, ray_address: str) -> None:
             both(config)
         elif config.mode == "bench":
             bench(config)
+        elif config.mode == "serve":
+            serve(config)
     finally:
         if config.monitor.enable_ray_timeline:
             timeline_file = os.path.join(config.monitor.cache_dir, "timeline.json")

--- a/trinity/cli/launcher.py
+++ b/trinity/cli/launcher.py
@@ -137,6 +137,15 @@ def both(config: Config) -> None:
         logger.error(f"Explorer or Trainer failed:\n{traceback.format_exc()}")
 
 
+MODE_MAP = {
+    "explore": explore,
+    "train": train,
+    "both": both,
+    "bench": bench,
+    "serve": serve,
+}
+
+
 def run_stage(config: Config, ray_address: str) -> None:
     envs = {
         PLUGIN_DIRS_ENV_VAR: os.environ.get(PLUGIN_DIRS_ENV_VAR, ""),
@@ -153,16 +162,7 @@ def run_stage(config: Config, ray_address: str) -> None:
     pprint(config)
     try:
         check_and_run_task_pipeline(config)
-        if config.mode == "explore":
-            explore(config)
-        elif config.mode == "train":
-            train(config)
-        elif config.mode == "both":
-            both(config)
-        elif config.mode == "bench":
-            bench(config)
-        elif config.mode == "serve":
-            serve(config)
+        MODE_MAP[config.mode](config)
     finally:
         if config.monitor.enable_ray_timeline:
             timeline_file = os.path.join(config.monitor.cache_dir, "timeline.json")

--- a/trinity/cli/launcher.py
+++ b/trinity/cli/launcher.py
@@ -63,6 +63,17 @@ def train(config: Config) -> None:
         logger.error(f"Trainer failed:\n{traceback.format_exc()}")
 
 
+def serve(config: Config) -> None:
+    """Run explorer in server mode."""
+    try:
+        explorer = Explorer.get_actor(config)
+        ray.get(explorer.prepare.remote())
+        ray.get(explorer.serve.remote())
+        ray.get(explorer.shutdown.remote())
+    except Exception:
+        logger.error(f"Explorer failed:\n{traceback.format_exc()}")
+
+
 def both(config: Config) -> None:
     """Setup both explorer and trainer.
 

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -421,11 +421,12 @@ class ExplorerConfig:
 
     # for serve mode
     api_port: int = 8010
+    # listen on all interfaces by default
     listen_address: str = "0.0.0.0"
-    service_status_check_interval: int = (
-        60  # check the running status of the server every 60 seconds
-    )
-    min_running_model_num: int = 1  # keep at least 1 model in running status
+    # check the running status of the server every 60 seconds
+    service_status_check_interval: int = 60
+    # keep at least 1 model in running status
+    min_running_model_num: int = 1
 
 
 @dataclass
@@ -934,7 +935,7 @@ class Config:
             * self.explorer.rollout_model.tensor_parallel_size
         )
         if (
-            self.mode in ["train", "explore", "bench"]
+            self.mode in ["train", "explore", "bench", "serve"]
             and self.synchronizer.sync_method == SyncMethod.NCCL
         ):
             self.synchronizer.sync_method = SyncMethod.CHECKPOINT

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -416,6 +416,7 @@ class ExplorerConfig:
 
     # for serve mode
     api_port: int = 8010
+    listen_address: str = "0.0.0.0"
     check_interval: int = 60  # check the status of models every 60 seconds
     min_running_model_num: int = 1  # keep at least 1 model in running status
 

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -161,9 +161,8 @@ class ExperiencePipelineConfig:
     # The list of experience operators to apply, operators will be applied in the order they are defined
     operators: List[OperatorConfig] = field(default_factory=list)
     save_input: bool = True  # whether to save the input experiences
-    input_save_path: Optional[
-        str
-    ] = None  # the path to save the input experiences, can be a jsonl file or a sqlite database file
+    # the path to save the input experiences, can be a jsonl file or a sqlite database file
+    input_save_path: Optional[str] = None
 
     # The following fields are experimental, do not set them unless you know what you are doing
 
@@ -423,7 +422,9 @@ class ExplorerConfig:
     # for serve mode
     api_port: int = 8010
     listen_address: str = "0.0.0.0"
-    check_interval: int = 60  # check the status of models every 60 seconds
+    service_status_check_interval: int = (
+        60  # check the running status of the server every 60 seconds
+    )
     min_running_model_num: int = 1  # keep at least 1 model in running status
 
 

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -414,6 +414,11 @@ class ExplorerConfig:
     # for benchmark
     bench_on_latest_checkpoint: bool = False  # only benchmark the latest checkpoint
 
+    # for serve mode
+    api_port: int = 8010
+    check_interval: int = 60  # check the status of models every 60 seconds
+    min_running_model_num: int = 1  # keep at least 1 model in running status
+
 
 @dataclass
 class TrainerConfig:

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -925,7 +925,7 @@ class Config:
         self._check_algorithm()
 
         # check mode
-        if self.mode not in ["explore", "train", "both", "bench"]:
+        if self.mode not in ["explore", "train", "both", "bench", "serve"]:
             raise ValueError(f"Invalid mode: {self.mode}")
 
         # prepare for the checkpoint directory

--- a/trinity/common/models/api/vllm_patch.py
+++ b/trinity/common/models/api/vllm_patch.py
@@ -362,6 +362,7 @@ async def run_api_server_in_ray_actor(
         str(port),
         "--model",
         model_path,
+        "--enable-server-load-tracking",  # enable tracking for load balancing
     ]
     if enable_auto_tool_choice:
         cli_args.append("--enable-auto-tool-choice")

--- a/trinity/common/models/model.py
+++ b/trinity/common/models/model.py
@@ -276,6 +276,10 @@ class ModelWrapper:
             data = response.json()
             return data["server_load"]
 
+    async def sync_model_weights(self, model_version: int) -> None:
+        """Sync the model weights"""
+        await self.model.sync_model.remote(model_version)
+
     @property
     def running_status(self) -> RunningStatus:
         """Get the running status of the model."""

--- a/trinity/common/models/model.py
+++ b/trinity/common/models/model.py
@@ -104,7 +104,7 @@ class ModelWrapper:
                     async with httpx.AsyncClient() as client:
                         response = await client.get(self.api_address + "/health", timeout=5)
                         if response.status_code == 200:
-                            break
+                            return
                 except Exception as e:
                     self.logger.info(f"API server not ready (attempt {i+1}/{max_retries}): {e}")
                 await asyncio.sleep(interval)

--- a/trinity/common/models/model.py
+++ b/trinity/common/models/model.py
@@ -108,7 +108,9 @@ class ModelWrapper:
                 except Exception as e:
                     self.logger.info(f"API server not ready (attempt {i+1}/{max_retries}): {e}")
                 await asyncio.sleep(interval)
-            self.logger.error(f"API server not ready after {max_retries} attempts.")
+            raise RuntimeError(
+                f"API server at {self.api_address} not ready after {max_retries} attempts."
+            )
 
     def _record_history(self, exps: Union[Experience, List[Experience]]) -> None:
         """Record experiences to history."""

--- a/trinity/common/models/model.py
+++ b/trinity/common/models/model.py
@@ -2,15 +2,16 @@
 """Base Model Class"""
 import asyncio
 import socket
-import time
 from abc import ABC, abstractmethod
-from typing import Any, List, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
+import httpx
 import openai
 import ray
 import torch
 from torch import Tensor
 
+from trinity.common.constants import RunningStatus
 from trinity.common.experience import Experience
 from trinity.utils.log import get_logger
 
@@ -46,6 +47,14 @@ class InferenceModel(ABC):
             port = s.getsockname()[1]
         return address, port
 
+    def has_api_server(self) -> bool:
+        """Check if the model has an API server."""
+        return False
+
+    def get_api_server_url(self) -> Optional[str]:
+        """Get the API server URL if available."""
+        return None
+
 
 def _history_recorder(func):
     """Decorator to record history of the model calls."""
@@ -77,6 +86,29 @@ class ModelWrapper:
         self.logger = get_logger(__name__)
         self.enable_history = enable_history
         self.history = []
+        self.status = RunningStatus.RUNNING
+        self.current_load = 0
+
+    async def prepare(self) -> None:
+        """Prepare the model wrapper."""
+        if await self.model.has_api_server.remote():
+            self.api_address = await self.model.get_api_server_url.remote()
+            if self.api_address is None:
+                raise RuntimeError(
+                    "Failed to connect to the API server. Please set `enable_openai_api` to `True`."
+                )
+            max_retries = 30
+            interval = 2  # seconds
+            for i in range(max_retries):
+                try:
+                    async with httpx.AsyncClient() as client:
+                        response = await client.get(self.api_address + "/health", timeout=5)
+                        if response.status_code == 200:
+                            break
+                except Exception as e:
+                    self.logger.info(f"API server not ready (attempt {i+1}/{max_retries}): {e}")
+                await asyncio.sleep(interval)
+            self.logger.error(f"API server not ready after {max_retries} attempts.")
 
     def _record_history(self, exps: Union[Experience, List[Experience]]) -> None:
         """Record experiences to history."""
@@ -172,31 +204,6 @@ class ModelWrapper:
         """Get the version of the model."""
         return await self.model.get_model_version.remote()
 
-    def _get_api_server_address(self) -> str:
-        """Get the address of the API server."""
-        if self.api_address:
-            return self.api_address
-        if not ray.get(self.model.has_api_server.remote()):
-            raise ValueError(
-                "OpenAI API server is not running on current model."
-                "Please set `enable_openai_api` to `True`."
-            )
-        api_address = None
-        while True:
-            api_address = ray.get(self.model.api_server_ready.remote())
-            if api_address is not None:
-                break
-            else:
-                self.logger.info("Waiting for OpenAI API server to be ready...")
-                time.sleep(5)
-        if api_address is None:
-            raise RuntimeError(
-                "Failed to connect to the API server. Please check the API server is running."
-            )
-        self.api_address = api_address
-        self.logger.info(f"Successfully connect to API server at {api_address}")
-        return api_address
-
     def get_openai_client(self) -> openai.OpenAI:
         """Get the openai client.
 
@@ -205,9 +212,12 @@ class ModelWrapper:
         """
         if self.openai_client is not None:
             return self.openai_client
-        api_address = self._get_api_server_address()
+        if not self.api_address:
+            raise ValueError(
+                "API server is not enabled for this model. OpenAI client is unavailable."
+            )
         self.openai_client = openai.OpenAI(
-            base_url=api_address,
+            base_url=f"{self.api_address}/v1",
             api_key="EMPTY",
         )
         if self.enable_history:
@@ -231,10 +241,13 @@ class ModelWrapper:
         """
         if self.openai_async_client is not None:
             return self.openai_async_client
+        if not self.api_address:
+            raise ValueError(
+                "API server is not enabled for this model. OpenAI async client is unavailable."
+            )
         # first make sure that we have the sync openai client
-        api_address = self._get_api_server_address()
         self.openai_async_client = openai.AsyncOpenAI(
-            base_url=api_address,
+            base_url=f"{self.api_address}/v1",
             api_key="EMPTY",
         )
         if self.enable_history:
@@ -251,6 +264,22 @@ class ModelWrapper:
         openai_client = self.get_openai_client()
         setattr(self.openai_async_client, "model_path", openai_client.models.list().data[0].id)
         return self.openai_async_client
+
+    async def get_load(self) -> int:
+        """Get the current load metrics of the model."""
+        if not self.api_address:
+            raise ValueError(
+                "API server is not enabled for this model. Load metrics is unavailable."
+            )
+        with httpx.AsyncClient() as client:
+            response = await client.get(f"{self.api_address}/load")
+            data = response.json()
+            return data["server_load"]
+
+    @property
+    def running_status(self) -> RunningStatus:
+        """Get the running status of the model."""
+        return self.status
 
     def extract_experience_from_history(self, clear_history: bool = True) -> List[Experience]:
         """Extract experiences from the history."""

--- a/trinity/common/models/model.py
+++ b/trinity/common/models/model.py
@@ -87,7 +87,7 @@ class ModelWrapper:
         self.enable_history = enable_history
         self.history = []
         self.status = RunningStatus.RUNNING
-        self.current_load = 0
+        self.request_count = 0
 
     async def prepare(self) -> None:
         """Prepare the model wrapper."""
@@ -267,7 +267,7 @@ class ModelWrapper:
         setattr(self.openai_async_client, "model_path", openai_client.models.list().data[0].id)
         return self.openai_async_client
 
-    async def get_load(self) -> int:
+    async def get_current_load(self) -> int:
         """Get the current load metrics of the model."""
         if not self.api_address:
             raise ValueError(
@@ -281,11 +281,6 @@ class ModelWrapper:
     async def sync_model_weights(self, model_version: int) -> None:
         """Sync the model weights"""
         await self.model.sync_model.remote(model_version)
-
-    @property
-    def running_status(self) -> RunningStatus:
-        """Get the running status of the model."""
-        return self.status
 
     def extract_experience_from_history(self, clear_history: bool = True) -> List[Experience]:
         """Extract experiences from the history."""

--- a/trinity/common/models/vllm_model.py
+++ b/trinity/common/models/vllm_model.py
@@ -385,12 +385,12 @@ class vLLMRolloutModel(InferenceModel):
                 method, timeout, args, kwargs
             )
 
-    async def sync_model(self, model_version: int) -> bool:
+    async def sync_model(self, model_version: int) -> int:
         """Sync model weights to vLLM."""
         await self._collective_rpc("update_weight")
         self.logger.info("Sync model weights to vLLM successfully.")
         self.model_version = model_version
-        return True
+        return model_version
 
     async def init_process_group(
         self,

--- a/trinity/common/models/vllm_model.py
+++ b/trinity/common/models/vllm_model.py
@@ -421,12 +421,7 @@ class vLLMRolloutModel(InferenceModel):
         )
 
     async def run_api_server(self):
-        """Run the OpenAI API server in a Ray actor.
-
-        Note:
-            Do not use `ray.get()` on this method.
-            This method will run forever until the server is shut down.
-        """
+        """Run the OpenAI API server in a Ray actor."""
         if not (self.api_server_host is None or self.api_server_port is None):
             raise RuntimeError("API server is already running.")
         from trinity.common.models.api.vllm_patch import run_api_server_in_ray_actor

--- a/trinity/explorer/api/api.py
+++ b/trinity/explorer/api/api.py
@@ -1,0 +1,40 @@
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+
+app = FastAPI()
+
+
+# Forward openAI requests to a model
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    url = await request.app.state.server.get_running_model_url()
+    async with httpx.AsyncClient() as client:
+        print(f"Forwarding request to {url}/v1/chat/completions")
+        print(f"Extra json: {body.get('task_id', {})}")
+        resp = await client.post(f"{url}/v1/chat/completions", json=body)
+    return resp.json()
+
+
+@app.get("/health")
+async def health(request: Request) -> Response:
+    """Health check."""
+    return Response(status_code=200)
+
+
+async def serve_http(app: FastAPI, port: int = None, localmode: bool = False):
+    host = "localhost" if localmode else "0.0.0.0"
+    config = uvicorn.Config(app, host=host, port=port)
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+async def run_app(server, port: int = None, localmode: bool = False) -> FastAPI:
+    app.state.server = server
+    port = port
+    print(f"API server running on localhost:{port}")
+    await serve_http(app, port, localmode=localmode)

--- a/trinity/explorer/api/api.py
+++ b/trinity/explorer/api/api.py
@@ -1,23 +1,41 @@
+import traceback
+
 import httpx
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 
 app = FastAPI()
 
 
-# Forward openAI requests to a model
+# Forward openAI requests to a model instance
 
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):
+    # Currently, we do not support streaming chat completions
     body = await request.json()
-    url = await request.app.state.server.get_running_model_url()
+    url = await request.app.state.service.allocate_model()
+    try:
+        async with httpx.AsyncClient(timeout=request.app.state.inference_timeout) as client:
+            resp = await client.post(f"{url}/v1/chat/completions", json=body)
+    except Exception:
+        return Response(
+            status_code=500,
+            content=f"Error forwarding request to model at {url}: {traceback.format_exc()}",
+        )
+    resp_data = resp.json()
+    await request.app.state.service.record_experience(resp_data)
+    return JSONResponse(content=resp_data)
+
+
+@app.get("/v1/models")
+async def show_available_models(request: Request):
+    body = await request.json()
+    url = await request.app.state.service.allocate_model(increase_count=False)
     async with httpx.AsyncClient() as client:
-        print(f"Forwarding request to {url}/v1/chat/completions")
-        print(f"Extra json: {body.get('task_id', {})}")
-        resp = await client.post(f"{url}/v1/chat/completions", json=body)
-    return resp.json()
+        resp = await client.get(f"{url}/v1/models", json=body)
+    return JSONResponse(content=resp.json())
 
 
 @app.get("/health")
@@ -26,13 +44,22 @@ async def health(request: Request) -> Response:
     return Response(status_code=200)
 
 
+@app.get("/metrics")
+async def metrics(request: Request):
+    """Get the metrics of the service."""
+    metrics = request.app.state.service.collect_metrics()
+    metrics["explore_step_num"] = request.app.state.service.explorer.explore_step_num
+    return JSONResponse(content=metrics)
+
+
 async def serve_http(app: FastAPI, host: str, port: int = None):
     config = uvicorn.Config(app, host=host, port=port)
     server = uvicorn.Server(config)
     await server.serve()
 
 
-async def run_app(server, listen_address: str, port: int = None) -> FastAPI:
-    app.state.server = server
+async def run_app(service, listen_address: str, port: int = None) -> FastAPI:
+    app.state.service = service
+    app.state.inference_timeout = service.explorer.config.synchronizer.sync_timeout
     print(f"API server running on {listen_address}:{port}")
     await serve_http(app, listen_address, port)

--- a/trinity/explorer/api/api.py
+++ b/trinity/explorer/api/api.py
@@ -26,15 +26,13 @@ async def health(request: Request) -> Response:
     return Response(status_code=200)
 
 
-async def serve_http(app: FastAPI, port: int = None, localmode: bool = False):
-    host = "localhost" if localmode else "0.0.0.0"
+async def serve_http(app: FastAPI, host: str, port: int = None):
     config = uvicorn.Config(app, host=host, port=port)
     server = uvicorn.Server(config)
     await server.serve()
 
 
-async def run_app(server, port: int = None, localmode: bool = False) -> FastAPI:
+async def run_app(server, listen_address: str, port: int = None) -> FastAPI:
     app.state.server = server
-    port = port
-    print(f"API server running on localhost:{port}")
-    await serve_http(app, port, localmode=localmode)
+    print(f"API server running on {listen_address}:{port}")
+    await serve_http(app, listen_address, port)

--- a/trinity/explorer/api/server.py
+++ b/trinity/explorer/api/server.py
@@ -36,7 +36,6 @@ class APIServer:
             self.running_models.append(i)
 
         self.serve_task = asyncio.create_task(run_app(self.explorer, self.port))
-        self.logger.info(f"API server started on port {self.port}")
 
     async def schedule_weights_sync(self, model_version: int):
         if not self.running:

--- a/trinity/explorer/api/server.py
+++ b/trinity/explorer/api/server.py
@@ -16,9 +16,7 @@ class APIServer:
         self.port = port
         self.localmode = localmode
         self.running = False
-        self.models: List[ModelWrapper] = [
-            ModelWrapper(model) for model in enumerate(explorer.models)
-        ]
+        self.models: List[ModelWrapper] = [ModelWrapper(model) for model in explorer.models]
         self.running_models: deque[int] = deque()
         self.requiring_sync_models: Set[int] = set()
         self.waiting_sync_models: Set[int] = set()
@@ -34,8 +32,8 @@ class APIServer:
         self.running = True
         await asyncio.gather(*[model.prepare() for model in self.models])
 
-        for model in self.models:
-            self.running_models.append(model)
+        for i, _ in enumerate(self.models):
+            self.running_models.append(i)
 
         self.serve_task = asyncio.create_task(run_app(self.explorer, self.port))
         self.logger.info(f"API server started on port {self.port}")
@@ -75,7 +73,7 @@ class APIServer:
             self.logger.warning("Server is not running.")
             return
         await asyncio.gather(
-            *[self._sync_model_weights(idx) for idx in list(self.requiring_sync_models.keys())]
+            *[self._sync_model_weights(idx) for idx in list(self.requiring_sync_models)]
         )
 
     async def write_buffer(self, experience):

--- a/trinity/explorer/api/server.py
+++ b/trinity/explorer/api/server.py
@@ -9,12 +9,12 @@ from trinity.utils.log import get_logger
 
 
 class APIServer:
-    def __init__(self, explorer: Explorer, port: int = 8010, localmode: bool = True):
+    def __init__(self, explorer: Explorer, listen_address: str = "localhost", port: int = 8010):
         self.logger = get_logger(__name__)
         self.explorer = explorer
         self.app = None
         self.port = port
-        self.localmode = localmode
+        self.listen_address = listen_address
         self.running = False
         self.models: List[ModelWrapper] = [ModelWrapper(model) for model in explorer.models]
         self.running_models: deque[int] = deque()
@@ -35,7 +35,9 @@ class APIServer:
         for i, _ in enumerate(self.models):
             self.running_models.append(i)
 
-        self.serve_task = asyncio.create_task(run_app(self.explorer, self.port))
+        self.serve_task = asyncio.create_task(
+            run_app(server=self, listen_address=self.listen_address, port=self.port)
+        )
 
     async def schedule_weights_sync(self, model_version: int):
         if not self.running:

--- a/trinity/explorer/api/service.py
+++ b/trinity/explorer/api/service.py
@@ -1,6 +1,7 @@
 import asyncio
+import time
 from collections import deque
-from typing import Dict, List, Set
+from typing import Dict, List
 
 import torch
 
@@ -20,9 +21,11 @@ class ExplorerService:
         self.listen_address = listen_address
         self.running = False
         self.models: List[ModelWrapper] = [ModelWrapper(model) for model in explorer.models]
-        self.running_models: deque[int] = deque()
-        self.requiring_sync_models: Set[int] = set()
-        self.waiting_sync_models: Set[int] = set()
+        self.min_running_model_num = explorer.config.explorer.min_running_model_num
+        self.check_interval = explorer.config.explorer.service_status_check_interval
+        self.max_timeout = explorer.config.explorer.max_timeout
+        self.running_models: deque[int] = deque()  # indices of running models
+        self.sync_task_map: Dict[asyncio.Future, int] = {}  # sync task -> model index
         self.latest_model_version = 0
         self.experience_queue = asyncio.Queue()
         self.experience_count = 0
@@ -43,31 +46,57 @@ class ExplorerService:
         self.serve_task = asyncio.create_task(
             run_app(service=self, listen_address=self.listen_address, port=self.port)
         )
+        self.sync_model_weights_task = asyncio.create_task(self.model_weights_sync_loop())
 
-    async def schedule_weights_sync(self, model_version: int):
-        if not self.running:
-            self.logger.warning("Server is not running.")
-            return
+    async def model_weights_sync_loop(self):
+        self.logger.info("Starting model weights synchronization loop.")
+        while self.running:
+            for idx in list(self.running_models):
+                if (
+                    len(self.running_models) > self.explorer.config.explorer.min_running_model_num
+                    and self.models[idx].model_version < self.latest_model_version
+                ):
+                    self.running_models.remove(idx)
+                    self.models[idx].status = RunningStatus.REQUIRE_SYNC
+                    self.logger.info(f"Model {idx} scheduled for synchronization.")
+                    future = asyncio.create_task(self._wait_for_sync_start(idx))
+                    self.sync_task_map[future] = idx
+                    future.add_done_callback(self._sync_model_weights)
+            # wait half interval
+            await asyncio.sleep(self.check_interval / 2)
+        self.logger.info("Model weights synchronization loop stopped.")
 
-        while len(self.running_models) > self.explorer.config.explorer.min_running_model_num:
-            if self.models[self.running_models[0]].model_version < self.latest_model_version:
-                idx = self.running_models.popleft()
-                self.requiring_sync_models.add(idx)
-                self.models[idx].status = RunningStatus.REQUIRE_SYNC
-                self.logger.info(f"Model {idx} scheduled for synchronization.")
-                asyncio.create_task(self.models[idx].sync_model_weights(self.latest_model_version))
+    def set_latest_model_version(self, version: int) -> None:
+        if version > self.latest_model_version:
+            self.latest_model_version = version
+            self.logger.info(f"Updated latest model version to {version}.")
 
-    async def _sync_model_weights(self, index: int):
-        if self.models[index].status != RunningStatus.REQUIRE_SYNC:
-            return
-        current_load = await self.models[index].get_current_load()
-        if current_load == 0:
-            self.models[index].status = RunningStatus.WAITING_SYNC
-            self.requiring_sync_models.remove(index)
-            self.waiting_sync_models.add(index)
-            self.logger.info(f"Model {index} begins synchronization.")
+    async def _wait_for_sync_start(self, index: int):
+        start_time = time.time()
+        while time.time() - start_time < self.max_timeout:
+            current_load = await self.models[index].get_current_load()
+            if current_load == 0:
+                self.models[index].status = RunningStatus.WAITING_SYNC
+                self.logger.info(f"Model {index} begins synchronization.")
+                return
+            else:
+                await asyncio.sleep(2)
+        raise asyncio.TimeoutError(
+            f"Timeout waiting for model {index} to be free for synchronization. Current load: {current_load}"
+        )
+
+    async def _sync_model_weights(self, task: asyncio.Future):
+        index = self.sync_task_map.pop(task)
+        latest_version = self.latest_model_version  # capture the latest version
+        if task.cancelled():
+            self.logger.warning(f"Synchronization of model {index} was cancelled.")
+        elif task.exception():
+            self.logger.error(f"Error during synchronization of model {index}: {task.exception()}")
         else:
-            self.logger.info(f"Model {index} still requires synchronization.")
+            await self.models[index].sync_model_weights(latest_version)
+            self.logger.info(f"Model {index} synchronized to version {latest_version}.")
+        self.running_models.append(index)
+        self.models[index].status = RunningStatus.RUNNING
 
     async def allocate_model(self, increase_count: bool = True) -> str:
         model = self.models[self.running_models[0]]
@@ -121,6 +150,7 @@ class ExplorerService:
         if not self.running:
             self.logger.warning("Server is not running.")
             return
+        self.sync_model_weights_task.cancel()
         self.serve_task.cancel()
         try:
             await self.serve_task

--- a/trinity/explorer/explorer.py
+++ b/trinity/explorer/explorer.py
@@ -421,7 +421,17 @@ class Explorer:
                 messages=[{"role": "user", "content": "Hello!"}]
             )
         """
-        pass
+        while True:
+            await asyncio.sleep(self.config.explorer.check_interval)
+            if await self.need_sync():
+                await self.continuous_sync_weight()
+
+    @Experimental
+    async def continuous_sync_weight(self) -> None:
+        """Synchronize model weights in a continuous way."""
+        latest_model_version = self.synchronizer.set_model_state_dict_weight_step_num()
+        self.server.latest_model_version = latest_model_version
+        await self.server.schedule_weights_sync(latest_model_version)
 
     @classmethod
     def get_actor(cls, config: Config):

--- a/trinity/explorer/explorer.py
+++ b/trinity/explorer/explorer.py
@@ -158,11 +158,6 @@ class Explorer:
             if self.config.mode != "serve":
                 self.scheduler = Scheduler(self.config, self.models, self.auxiliary_models)
                 await self.scheduler.start()
-            else:
-                from trinity.explorer.api.server import APIServer
-
-                self.server = APIServer(self, self.config.explorer.api_port, self.config.localmode)
-                await self.server.serve()
             if self.config.explorer.eval_on_startup and self.explore_step_num == 0:
                 await self.eval()
 
@@ -421,6 +416,13 @@ class Explorer:
                 messages=[{"role": "user", "content": "Hello!"}]
             )
         """
+        from trinity.explorer.api.server import APIServer
+
+        self.server = APIServer(self, self.config.explorer.api_port, self.config.localmode)
+        await self.server.serve()
+        self.server_url = f"http://{ray.util.get_node_ip_address()}:{self.server.port}"
+        self.logger.info(f"Explorer API Server is started on {self.server_url}")
+        self.state.save_explorer_server_url(self.server_url)
         while True:
             await asyncio.sleep(self.config.explorer.check_interval)
             self.experience_pipeline.process.remote([])

--- a/trinity/explorer/explorer.py
+++ b/trinity/explorer/explorer.py
@@ -423,6 +423,7 @@ class Explorer:
         """
         while True:
             await asyncio.sleep(self.config.explorer.check_interval)
+            self.experience_pipeline.process.remote([])
             if await self.need_sync():
                 await self.continuous_sync_weight()
 

--- a/trinity/explorer/explorer_client.py
+++ b/trinity/explorer/explorer_client.py
@@ -1,0 +1,64 @@
+from functools import partial
+
+import httpx
+import openai
+import requests
+
+
+class ExplorerClient:
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+        self.session_id = self.init_session()
+
+    def init_session(self) -> str:
+        response = requests.post(f"{self.base_url}/allocate")
+        data = response.json()
+        return data["session_id"]
+
+    def get_openai_client(self) -> openai.OpenAI:
+        client = openai.OpenAI(
+            base_url=self.base_url + "/v1",
+            api_key="EMPTY",
+        )
+        client.chat.completions.create = partial(
+            self._create_chat_completion, extra_body={"session_id": self.session_id}
+        )
+        return client
+
+    def get_openai_async_client(self) -> openai.OpenAIAsync:
+        client = openai.OpenAIAsync(
+            base_url=self.base_url + "/v1",
+            api_key="EMPTY",
+        )
+        client.chat.completions.create = partial(
+            self._create_chat_completion_async, extra_body={"session_id": self.session_id}
+        )
+        return client
+
+    def feedback(self, reward: float):
+        response = requests.post(
+            f"{self.base_url}/feedback", json={"session_id": self.session_id, "reward": reward}
+        )
+        return response.json()
+
+    async def feedback_async(self, reward: float):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/feedback", json={"session_id": self.session_id, "reward": reward}
+            )
+            return response.json()
+
+    def _create_chat_completion(self, *args, extra_body=None, **kwargs):
+        if extra_body is None:
+            extra_body = {}
+        body = {**kwargs, **extra_body}
+        response = requests.post(f"{self.base_url}/v1/chat/completions", json=body)
+        return response.json()
+
+    async def _create_chat_completion_async(self, *args, extra_body=None, **kwargs):
+        if extra_body is None:
+            extra_body = {}
+        body = {**kwargs, **extra_body}
+        async with httpx.AsyncClient() as client:
+            response = await client.post(f"{self.base_url}/v1/chat/completions", json=body)
+            return response.json()

--- a/trinity/explorer/explorer_client.py
+++ b/trinity/explorer/explorer_client.py
@@ -21,17 +21,17 @@ class ExplorerClient:
             api_key="EMPTY",
         )
         client.chat.completions.create = partial(
-            self._create_chat_completion, extra_body={"session_id": self.session_id}
+            client.chat.completions.create, extra_body={"session_id": self.session_id}
         )
         return client
 
-    def get_openai_async_client(self) -> openai.OpenAIAsync:
-        client = openai.OpenAIAsync(
+    def get_openai_async_client(self) -> openai.AsyncOpenAI:
+        client = openai.AsyncOpenAI(
             base_url=self.base_url + "/v1",
             api_key="EMPTY",
         )
         client.chat.completions.create = partial(
-            self._create_chat_completion_async, extra_body={"session_id": self.session_id}
+            client.chat.completions.create, extra_body={"session_id": self.session_id}
         )
         return client
 
@@ -46,19 +46,4 @@ class ExplorerClient:
             response = await client.post(
                 f"{self.base_url}/feedback", json={"session_id": self.session_id, "reward": reward}
             )
-            return response.json()
-
-    def _create_chat_completion(self, *args, extra_body=None, **kwargs):
-        if extra_body is None:
-            extra_body = {}
-        body = {**kwargs, **extra_body}
-        response = requests.post(f"{self.base_url}/v1/chat/completions", json=body)
-        return response.json()
-
-    async def _create_chat_completion_async(self, *args, extra_body=None, **kwargs):
-        if extra_body is None:
-            extra_body = {}
-        body = {**kwargs, **extra_body}
-        async with httpx.AsyncClient() as client:
-            response = await client.post(f"{self.base_url}/v1/chat/completions", json=body)
             return response.json()

--- a/trinity/manager/state_manager.py
+++ b/trinity/manager/state_manager.py
@@ -81,6 +81,7 @@ class StateManager:
     def save_explorer_server_url(self, url: str) -> None:
         with open(self.explorer_server_url_path, "w", encoding="utf-8") as f:
             f.write(url)
+        self.logger.info(f"Saved explorer server URL to {self.explorer_server_url_path}")
 
     def load_explorer_server_url(self) -> Optional[str]:
         if os.path.exists(self.explorer_server_url_path):

--- a/trinity/manager/state_manager.py
+++ b/trinity/manager/state_manager.py
@@ -21,16 +21,19 @@ class StateManager:
     ):
         self.logger = get_logger(__name__, in_ray_actor=True)
         self.cache_dir = path
-        os.makedirs(self.cache_dir, exist_ok=True)  # type: ignore
-        self.stage_state_path = os.path.join(self.cache_dir, "stage_meta.json")  # type: ignore
-        self.explorer_state_path = os.path.join(self.cache_dir, f"{explorer_name}_meta.json")  # type: ignore
-        self.trainer_state_path = os.path.join(self.cache_dir, f"{trainer_name}_meta.json")  # type: ignore
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.stage_state_path = os.path.join(self.cache_dir, "stage_meta.json")
+        self.explorer_state_path = os.path.join(self.cache_dir, f"{explorer_name}_meta.json")
+        self.trainer_state_path = os.path.join(self.cache_dir, f"{trainer_name}_meta.json")
+        self.explorer_server_url_path = os.path.join(
+            self.cache_dir, f"{explorer_name}_server_url.txt"
+        )
         if check_config and config is not None:
             self._check_config_consistency(config)
 
     def _check_config_consistency(self, config: Config) -> None:
         """Check if the config is consistent with the cache dir backup."""
-        backup_config_path = os.path.join(self.cache_dir, "config.json")  # type: ignore
+        backup_config_path = os.path.join(self.cache_dir, "config.json")
         if not os.path.exists(backup_config_path):
             config.save(backup_config_path)
         else:
@@ -74,6 +77,26 @@ class StateManager:
             except Exception as e:
                 self.logger.error(f"Failed to load explore state file: {e}")
         return {}
+
+    def save_explorer_server_url(self, url: str) -> None:
+        with open(self.explorer_server_url_path, "w", encoding="utf-8") as f:
+            f.write(url)
+
+    def load_explorer_server_url(self) -> Optional[str]:
+        if os.path.exists(self.explorer_server_url_path):
+            try:
+                with open(self.explorer_server_url_path, "r", encoding="utf-8") as f:
+                    url = f.read().strip()
+                self.logger.info(
+                    "----------------------------------\n"
+                    "Found existing explorer server URL:\n"
+                    f"  > {url}\n"
+                    "----------------------------------"
+                )
+                return url
+            except Exception as e:
+                self.logger.error(f"Failed to load explorer server URL file: {e}")
+        return None
 
     def save_trainer(
         self,


### PR DESCRIPTION
## Description

Propose `serve` mode in this PR.

In `serve` mode

- Only Explorer will be started, and the `buffer.explorer_input` will be ignored. 
- Explorer provides an OpenAI API-compatible inference service.
- Explorer dynamically assigns requests to the inference models within it.
- Explorer automatically converts inference requests and responses into `Experience` data and write them to buffer.
- Explorer keeps tracking the latest checkpoint generated by Trainer (which can be run in another cluster)
- Explorer ensures that there is at least one running (not syncing weights) inference model at any time.


With `serve` mode, agent application developers can deploy their Agent applications locally and use the inference services provided by a remote Explorer.



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review
