### PR TITLE
Add sequence mask for grpo

### DIFF
--- a/tests/algorithm/policy_loss_test.py
+++ b/tests/algorithm/policy_loss_test.py
@@ -120,7 +120,7 @@ class VerlPolicyLossTest(unittest.TestCase):
         policy_loss_fn_cls = POLICY_LOSS_FN.get("ppo")
         policy_loss_fn_args = policy_loss_fn_cls.default_args()
         policy_loss_fn_args["enable_sequence_masking"] = True
-        policy_loss_fn_args["delta"] = 0.1
+        policy_loss_fn_args["delta_sequence_masking"] = 0.1
         policy_loss_fn = policy_loss_fn_cls(**policy_loss_fn_args)
         loss, metrics = policy_loss_fn(log_prob=self.logprob, **self.input_data.batch)
         ppo_loss_masked = torch.tensor(0.22175675630569458)


### PR DESCRIPTION
## Description

Here we implement the sequence masking formula introduced in [DeepSeek V3.2 paper](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/assets/paper.pdf)

<img width="867" height="502" alt="image" src="https://github.com/user-attachments/assets/88692a74-a2e1-4f25-8ea1-b9dc1c20b638" />


Since the $\delta$ hyperparameter is not given a recommended value in the original paper, we further tested the influence of $\delta$. It seems that setting the range from `0.05` to `0.2` is reasonable.

<img width="1092" height="500" alt="image" src="https://github.com/user-attachments/assets/3ce20c57-b956-43b7-94f9-fc02b59f2a4a" />



## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
