### PR TITLE
Fix: skip trainer config validation in bench mode

### DIFF
--- a/trinity/common/config_validator.py
+++ b/trinity/common/config_validator.py
@@ -1165,7 +1165,7 @@ class TrainerConfigValidator(ConfigValidator):
                        or save checkpoint strategy is invalid.
         """
         if (
-            config.mode not in ["train", "both", "bench", "colocate"]
+            config.mode not in ["train", "both", "colocate"]
             and config.trainer.trainer_strategy != "megatron"
         ):
             return


### PR DESCRIPTION
## Bug

In `bench` mode, `cluster.trainer_gpu_num` is left at its default `0` because the cluster validator deliberately skips trainer GPU allocation for `bench` / `explore` / `serve` (these modes don't train) — see [`config_validator.py:244`](https://github.com/modelscope/Trinity-RFT/blob/main/trinity/common/config_validator.py#L244).

But the trainer config validator (`config_validator.py:1168`) still keeps `bench` in its whitelist. So for any local-model bench run (i.e. `external_model.enable=false`), the call chain reaches:

```
trinity/trainer/verl/verl_config.py:430
    if train_batch_size % (world_size // sp_size) != 0:
                              ↑ trainer_gpu_num = 0 → ZeroDivisionError
```

Repro: any yaml with `mode: bench` + a non-external model + `engine_num × tensor_parallel_size = total GPU`.

## Fix

Drop `bench` from the trainer-config-check whitelist. Bench mode runs explorer-only and never touches the trainer, so its trainer parallelism config doesn't need validation. Same fast-path semantics as the existing `external_model.enable=true` check immediately below at line 1170.

After the fix, all 6 modes behave correctly:

| mode      | trainer GPU allocated | trainer config check |
|-----------|------------------------|----------------------|
| train     | yes                    | yes                  |
| both      | yes                    | yes                  |
| colocate  | yes (1 GPU placeholder)| yes                  |
| bench     | no                     | **no** (was: yes, broken) |
| explore   | no                     | no (already)         |
| serve     | no                     | no (already)         |

## Test

A local-model bench run (Qwen3.6-27B + frozen_lake_obscure eval, 1 node × 8 GPU, `engine_num=4` × `TP=2`) reproduces the `ZeroDivisionError` on main and runs cleanly with this patch.

`config.trainer.trainer_config` is not accessed by any module outside `config_validator.py` (verified via repo-wide grep), so skipping `synchronize_config()` in bench mode has no downstream effect.