### PR TITLE
fix(trainer): add empty_cache() after compute_ref_log_prob to prevent OOM

### DIFF
--- a/trinity/trainer/verl/fsdp_workers.py
+++ b/trinity/trainer/verl/fsdp_workers.py
@@ -1040,6 +1040,11 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         output = output.to("cpu")
 
+        # Release reserved GPU memory after ref model forward pass.
+        # Without this, memory_reserved grows after each ref_log_prob call,
+        # eventually causing OOM in subsequent training steps.
+        torch.cuda.empty_cache()
+
         # https://pytorch.org/docs/stable/notes/fsdp.html#fsdp-notes
         # unshard the root FSDP module
         if self.world_size > 1:


### PR DESCRIPTION
## Summary

Add `torch.cuda.empty_cache()` after the reference model forward pass in `compute_ref_log_prob()`.

This complements #541 which added `empty_cache()` after `update_policy()` for the actor path. The ref model path has the same memory leak issue.

### Root Cause

In colocate mode, vLLM and FSDP trainer share the same GPU. During `compute_ref_log_prob()`, the ref model creates large intermediate tensors (logits with `vocab_size` up to 248K). After `output.to("cpu")` moves the result to CPU, PyTorch's caching allocator still **reserves** the GPU memory used by these intermediates. This reserved memory grows monotonically across training steps and is never released back to CUDA, eventually causing OOM.

### What This PR Does

Adds `torch.cuda.empty_cache()` right after `output = output.to("cpu")` in `compute_ref_log_prob()`, releasing the caching allocator's reserved memory back to CUDA so it can be reused by vLLM and subsequent training steps.

### Verification

Tested on A100 80GB with Qwen3.5-0.8B in colocate mode:

| Metric | Without patch | With patch |
|--------|--------------|------------|
| OOM at step 2 | Yes (77 GiB reserved) | No |
| Stable memory | N/A | ~40 GiB reserved |
| Training steps completed | 1 | 5+ |

The fix is a single 3-line addition (comment + `empty_cache()` call) with no behavioral changes to training logic.

### Related

- #541 — `empty_cache()` after `update_policy()` (already merged)