### PR TITLE
fix(sglang): fix shutdown Gloo connection error

### DIFF
--- a/tests/common/experience_test.py
+++ b/tests/common/experience_test.py
@@ -449,7 +449,8 @@ class TestExperienceConversion(unittest.TestCase):
         )
 
         model = ExperienceModel.from_experience(experience)
-        new_experience = model.to_experience()
+        blob_bytes = experience.serialize()
+        new_experience = model.to_experience(blob_bytes)
         self.assertTrue(torch.equal(new_experience.tokens, tokens))
         self.assertEqual(new_experience.prompt_length, prompt_length)
         self.assertEqual(new_experience.reward, reward)

--- a/tests/explorer/workflow_test.py
+++ b/tests/explorer/workflow_test.py
@@ -59,6 +59,8 @@ class MockResponse:
     tokens: Optional[Tensor] = Tensor([0, 0])
     prompt_length: int = 1
     eid: EID = field(default_factory=EID)
+    truncate_status: str = "not_truncated"
+    action_mask: Optional[Tensor] = None
 
 
 class DummyWorkflow(Workflow):

--- a/trinity/common/models/sglang_patch/server_patch.py
+++ b/trinity/common/models/sglang_patch/server_patch.py
@@ -103,8 +103,7 @@ def _create_cleanup(
 
             # Send SIGTERM to all alive processes simultaneously
             alive_processes = [
-                p for p in processes
-                if p is not None and p.pid is not None and p.is_alive()
+                p for p in processes if p is not None and p.pid is not None and p.is_alive()
             ]
 
             for process in alive_processes:

--- a/trinity/common/models/sglang_patch/server_patch.py
+++ b/trinity/common/models/sglang_patch/server_patch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from logging import Logger
 from typing import Callable, Coroutine, Dict, List, Optional
 
@@ -98,17 +99,41 @@ def _create_cleanup(
 
         if subprocess_watchdog is not None:
             subprocess_watchdog.stop()
-            for process in getattr(subprocess_watchdog, "_processes", []):
-                if process is None or process.pid is None:
-                    continue
+            processes = getattr(subprocess_watchdog, "_processes", [])
+
+            # Send SIGTERM to all alive processes simultaneously
+            alive_processes = [
+                p for p in processes
+                if p is not None and p.pid is not None and p.is_alive()
+            ]
+
+            for process in alive_processes:
                 try:
-                    kill_process_tree(process.pid, wait_timeout=60)
+                    process.terminate()
                 except Exception as exc:
-                    logger.warning(
-                        "Failed to terminate SGLang child process %s: %s",
-                        process.pid,
-                        exc,
-                    )
+                    logger.warning("Failed to send SIGTERM: %s", exc)
+
+            if alive_processes:
+                # Wait for graceful exit
+                graceful_timeout = 5
+                start_time = time.time()
+                while time.time() - start_time < graceful_timeout:
+                    if not any(p.is_alive() for p in alive_processes):
+                        logger.info("All SGLang subprocesses exited gracefully.")
+                        break
+                    await asyncio.sleep(0.2)
+
+                # Force kill remaining processes
+                still_alive = [p for p in alive_processes if p.is_alive()]
+                for process in still_alive:
+                    try:
+                        kill_process_tree(process.pid, wait_timeout=60)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to terminate SGLang child process %s: %s",
+                            process.pid,
+                            exc,
+                        )
         elif server_args.node_rank > 0:
             kill_process_tree(os.getpid(), include_parent=False, wait_timeout=60)
 


### PR DESCRIPTION
This fixes Gloo "Connection reset by peer" errors during shutdown by allowing processes to exit cleanly rather than being killed mid-collective operation.

1. Send SIGTERM to all scheduler processes simultaneously instead of SIGKILL
2. Wait up to 5 seconds for graceful exit
3. Use kill_process_tree for remaining processes

## Description

[Please describe the background, purpose, changes made, and how to test this PR]


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
