### PR TITLE
fix(sglang): fix sglang oom (Qwen3.5-35B-A3B)

### DIFF
--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -581,6 +581,9 @@ class InferenceModelConfig:
     node_rank: int = 0
     enable_return_routed_experts: bool = False
 
+    # Buffer size (bytes) for batched NCCL weight sync. Controls peak GPU memory during sync.
+    weight_sync_buffer_size: int = 4 * 1024 * 1024 * 1024  # 4 GB
+
     # ! DO NOT SET
     bundle_indices: str = ""
     engine_id: int = 0

--- a/trinity/common/models/sglang_model.py
+++ b/trinity/common/models/sglang_model.py
@@ -117,6 +117,26 @@ class SGLangClient:
             )
         return success
 
+    async def flush_cache(self, timeout: float = 30) -> bool:
+        """Flush KV and Mamba cache to free GPU memory before weight sync."""
+        import httpx
+
+        url = f"{self.server_url}/flush_cache"
+        try:
+            async with httpx.AsyncClient(
+                headers={"Authorization": f"Bearer {self.api_key}" if self.api_key else ""}
+            ) as client:
+                response = await client.post(url, timeout=timeout)
+                if response.status_code == 200:
+                    return True
+                self.logger.warning(
+                    f"flush_cache returned status {response.status_code}: {response.text}"
+                )
+                return False
+        except Exception as e:
+            self.logger.warning(f"Failed to flush cache: {e}")
+            return False
+
     async def update_weights_from_distributed(
         self,
         state_dict_meta_list: List[Tuple[str, str, Tuple]],
@@ -535,6 +555,9 @@ class SGLangRolloutModel(BaseInferenceModel):
         self.logger.info(f"Synchronizing model to version {model_version} using method {method}...")
         if method == SyncMethod.NCCL:
             assert self.state_dict_meta, "state_dict_meta must be initialized for NCCL sync"
+            # Flush KV + Mamba cache to free GPU memory for receive buffers
+            await self.api_client.flush_cache()
+            self.logger.info("Flushed KV/Mamba cache before NCCL weight sync")
             batches = self._partition_state_dict_meta(self.state_dict_meta)
             self.logger.info(
                 f"NCCL weight sync: {len(self.state_dict_meta)} tensors in {len(batches)} batches "

--- a/trinity/common/models/sglang_model.py
+++ b/trinity/common/models/sglang_model.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import operator
 import os
 import traceback
+from functools import reduce
 from logging import Logger
 from typing import Any, List, Literal, Optional, Sequence, Tuple
 
@@ -533,12 +535,20 @@ class SGLangRolloutModel(BaseInferenceModel):
         self.logger.info(f"Synchronizing model to version {model_version} using method {method}...")
         if method == SyncMethod.NCCL:
             assert self.state_dict_meta, "state_dict_meta must be initialized for NCCL sync"
-            await self.api_client.update_weights_from_distributed(
-                state_dict_meta_list=self.state_dict_meta,
-                group_name=self.group_name,
-                weight_version=str(model_version),
-                timeout=timeout,
+            batches = self._partition_state_dict_meta(self.state_dict_meta)
+            self.logger.info(
+                f"NCCL weight sync: {len(self.state_dict_meta)} tensors in {len(batches)} batches "
+                f"(buffer_size={self.config.weight_sync_buffer_size / 1024**3:.1f} GB)"
             )
+            for i, batch in enumerate(batches):
+                is_last = i == len(batches) - 1
+                await self.api_client.update_weights_from_distributed(
+                    state_dict_meta_list=batch,
+                    group_name=self.group_name,
+                    weight_version=str(model_version),
+                    flush_cache=is_last,
+                    timeout=timeout,
+                )
             self.model_version = model_version
         elif method == SyncMethod.CHECKPOINT:
             model_path = await self.synchronizer.get_latest_model_path.remote(use_huggingface=True)
@@ -553,6 +563,39 @@ class SGLangRolloutModel(BaseInferenceModel):
             raise ValueError(f"Unsupported sync method for SGLang: {method}")
         self.logger.info("Synchronization finished.")
         return model_version
+
+    def _partition_state_dict_meta(
+        self, meta_list: "List[Tuple[str, str, Tuple]]"
+    ) -> "List[List[Tuple[str, str, Tuple]]]":
+        """Partition state_dict_meta into batches that fit within weight_sync_buffer_size.
+
+        This prevents OOM during NCCL weight sync by ensuring SGLang only allocates
+        receive buffers for one batch at a time, rather than all tensors simultaneously.
+        """
+        buffer_size = self.config.weight_sync_buffer_size
+
+        batches: list = []
+        current_batch: list = []
+        current_size = 0
+
+        for item in meta_list:
+            name, dtype_str, shape = item
+            dtype = getattr(torch, dtype_str, torch.bfloat16)
+            elem_size = torch.tensor([], dtype=dtype).element_size()
+            tensor_bytes = reduce(operator.mul, shape, 1) * elem_size
+
+            if current_size + tensor_bytes > buffer_size and current_batch:
+                batches.append(current_batch)
+                current_batch = []
+                current_size = 0
+
+            current_batch.append(item)
+            current_size += tensor_bytes
+
+        if current_batch:
+            batches.append(current_batch)
+
+        return batches
 
     def get_model_version(self) -> int:
         return self.model_version


### PR DESCRIPTION
## Description

When running Qwen3.5-35B-A3B (Hybrid MoE + Mamba, ~63.4 GB total weights) with NCCL-based weight sync from Trainer to SGLang Explorer, SGLang allocates receive buffers
 for all tensors simultaneously, causing OOM on H20 GPUs (95 GiB each, ~50 GiB available after model loading).

 A secondary OOM occurs on Hybrid Mamba models because SGLang pre-allocates Mamba state memory (mamba_full_memory_ratio=0.9), consuming nearly all remaining GPU memory —
  leaving no room even for batched receive buffers.

 ## Fix

  Commit 1 — Batched weight sync:
  - Partition state_dict_meta into configurable batches (default 4 GB each, controlled by InferenceModelConfig.weight_sync_buffer_size)
  - Call update_weights_from_distributed once per batch instead of once for all tensors
  - SGLang allocates/releases buffers per batch, keeping peak memory bounded
  
  Commit 2 — Flush cache before sync:
  - Call SGLang's /flush_cache endpoint before starting NCCL weight sync
  - Releases KV + Mamba cache (~73 GiB across 8 GPUs), making room for receive buffers
  - Cache is automatically repopulated on next inference request
  
 ## Files Changed

  - trinity/common/models/sglang_model.py — batching logic, flush_cache() client method, sync flow update
  - trinity/common/config.py — add weight_sync_buffer_size field to InferenceModelConfig

## What to Verify

  1. Weight sync completes without OOM — look for log lines:
  Flushed KV/Mamba cache before NCCL weight sync
  NCCL weight sync: XXX tensors in 21 batches (buffer_size=4.0 GB)
  Synchronization finished.
  2. Rollout succeeds after sync — model generates valid responses after weights are updated
  3. Training step proceeds — trainer consumes the rollout experiences and completes a step
  Verified
  
  
example.yaml 👇
  
 

> project: Trinity-RFT-example
name: trinity-dapo
checkpoint_root_dir: ${oc.env:TRINITY_CHECKPOINT_ROOT_DIR,./checkpoints}
model:
  model_path: ${oc.env:TRINITY_MODEL_PATH} # Suggest using larger model on this dataset
  max_response_tokens: 256
  max_model_len: 1024
algorithm:
  enable_router_replay: true
  algorithm_type: grpo
  repeat_times: 4
  optimizer:
    lr: 1e-6
    lr_warmup_steps: 20
  policy_loss_fn_args:
    clip_range_low: 0.2
    clip_range_high: 0.28
cluster:
  node_num: 4
  gpu_per_node: 8
buffer:
  total_steps: 2
  batch_size: 8
  explorer_input:
    taskset:
      name: dapo-math
      storage_type: file
      path: /nas/xiqing/datasets/trinity/dapo-math-17k
      subset_name: all
      format:
        prompt_key: 'prompt'
        response_key: 'solution'
        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.'
      rollout_args:
        temperature: 1.0
      workflow_args:
        use_base: true
      reward_fn_args:
        enable_overlong_penalty: true
        penalty_factor: 1.0
        max_response_length: 8192
        cache_length: 256
    eval_tasksets:
    - name: AIME2024
      storage_type: file
      path: /nas/xiqing/datasets/trinity/aime24
      split: 'train'
      repeat_times: 2
      format:
        prompt_key: 'question'
        response_key: 'answer'
        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.'
      rollout_args:
        temperature: 1.0
        top_p: 1
    default_workflow_type: 'math_boxed_workflow'
    default_reward_fn_type: 'math_dapo_reward'
  trainer_input:
    experience_buffer:
      name: math_buffer
      storage_type: queue
explorer:
  eval_interval: 20
  runner_per_model: 4
  rollout_model:
    engine_type: sglang
    engine_num: 4
    tensor_parallel_size: 4
    enforce_eager: true
    enable_prefix_caching: true
    enable_chunked_prefill: true
    gpu_memory_utilization: 0.4
    dtype: bfloat16
    seed: 42
synchronizer:
  sync_method: 'nccl'
  sync_interval: 16
  sync_timeout: 1200
trainer:
  save_interval: 100
  grad_clip: 1.0
  use_dynamic_bsz: true
  max_token_len_per_gpu: 256
  trainer_strategy: megatron
  trainer_config:
    actor_rollout_ref:
      actor:
        megatron:
          tensor_model_parallel_size: 4
          pipeline_model_parallel_size: 1
          expert_model_parallel_size: 8
          expert_tensor_parallel_size: 1
          context_parallel_size: 1
          sequence_parallel: true
          use_dynamic_bsz: true
          use_remove_padding: true
          use_distributed_optimizer: true
          override_transformer_config:
          recompute_granularity: full
          recompute_method: uniform
          recompute_num_layers: 1



## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
