### PR TITLE
fix: propagate the optional 'group' config field across paths, namespaces & docs

### DIFF
--- a/docs/sphinx_doc/source/tutorial/align_with_verl.md
+++ b/docs/sphinx_doc/source/tutorial/align_with_verl.md
@@ -152,7 +152,7 @@ Please refer to the [configuration](https://github.com/agentscope-ai/Trinity-RFT
 | `trainer.logger` | `monitor.monitor_type` | Support a chosen type and (no need to set) `console` |
 | `trainer.project_name` | `project` | - |
 | `trainer.experiment_name` | `name` | - |
-| `trainer.default_local_dir` | `checkpoint_root_dir` | Checkpoint is saved in `<checkpoint_root_dir>/<project>/<name>/` |
+| `trainer.default_local_dir` | `checkpoint_root_dir` | Checkpoint is saved in `<checkpoint_root_dir>/<project>/<group>/<name>/` |
 | `trainer.n_gpus_per_node` | `cluster.gpu_per_node` | - |
 | `trainer.nnodes` | `cluster.node_num` | - |
 | `trainer.save_freq` | `trainer.save_interval` | - |
@@ -166,7 +166,7 @@ Please refer to the [configuration](https://github.com/agentscope-ai/Trinity-RFT
 
 💡 Detailed explanation:
 
-* If you want to resume training from a checkpoint, you can set `continue_from_checkpoint` to `True` and the training will start from the latest checkpoint in the checkpoint path `<checkpoint_root_dir>/<project>/<name>/` (if any).
+* If you want to resume training from a checkpoint, you can set `continue_from_checkpoint` to `True` and the training will start from the latest checkpoint in the checkpoint path `<checkpoint_root_dir>/<project>/<group>/<name>/` (if any).
 
 
 ## GPU Resource Allocation

--- a/docs/sphinx_doc/source/tutorial/develop_workflow.md
+++ b/docs/sphinx_doc/source/tutorial/develop_workflow.md
@@ -538,7 +538,7 @@ class Workflow(ABC):
         self.logger = get_logger(__name__)  # built-in logger for runtime monitoring
 ```
 
-Different from standard Python loggers, this built-in logger is configured to output logs to both the console and a file under the `<checkpoint_root_dir>/<project>/<name>/log` directory. This allows you to monitor the workflow's runtime status during training conveniently. All workflow subclasses inherit this logger, so you can directly use it in your custom workflow implementations with `self.logger`.
+Different from standard Python loggers, this built-in logger is configured to output logs to both the console and a file under the `<checkpoint_root_dir>/<project>/<group>/<name>/log` directory. This allows you to monitor the workflow's runtime status during training conveniently. All workflow subclasses inherit this logger, so you can directly use it in your custom workflow implementations with `self.logger`.
 
 ```python
 class ExampleWorkflow(Workflow):
@@ -555,7 +555,7 @@ Trinity-RFT will automatically create a group of workflow runners to execute the
 Each runner will log its output to a separate log file. The log file naming convention is `explorer_runner_<runner_id>.log`, where `<runner_id>` is the unique identifier of the workflow runner. Such design allows you to trace the execution of each workflow runner independently. And the log files are organized as follows:
 
 ```
-<checkpoint_root_dir>/<project>/<name>/log/
+<checkpoint_root_dir>/<project>/<group>/<name>/log/
     ├── explorer_runner_0.log
     ├── explorer_runner_1.log
     ├── explorer_runner_2.log

--- a/docs/sphinx_doc/source/tutorial/example_reasoning_basic.md
+++ b/docs/sphinx_doc/source/tutorial/example_reasoning_basic.md
@@ -119,16 +119,16 @@ trinity run --config examples/grpo_gsm8k/gsm8k.yaml
 
 ## Optional: Convert Checkpoints to Hugging Face Format
 
-After running Trinity-RFT experiments, the system automatically saves training checkpoints to the following path:
+After running Trinity-RFT experiments, the system automatically saves training checkpoints to the following path (the `${group}` segment is optional and omitted when `group` is empty, i.e. `${project}/${name}` by default):
 
 ```
-${checkpoint_root_dir}/${project}/${name}
+${checkpoint_root_dir}/${project}/${group}/${name}
 ```
 
 The directory structure is as follows:
 
 ```
-${checkpoint_root_dir}/${project}/${name}
+${checkpoint_root_dir}/${project}/${group}/${name}
 ├── buffer
 │   ├── experience_buffer.jsonl          # Stores experience data generated during training
 │   └── explorer_output.db               # Database file output by the Explorer module
@@ -177,7 +177,7 @@ The `trinity convert` command provides flexible model conversion capabilities an
 Point `--checkpoint-dir` to your project root directory (i.e., the path containing multiple `global_step_*` subdirectories). The tool will **automatically recursively scan for all `global_step_*` directories** and convert each checkpoint accordingly.
 
 ```bash
-trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}
+trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name}
 ```
 
 This command will:
@@ -189,7 +189,7 @@ This command will:
 If you only want to convert a model from a specific training step, directly point `--checkpoint-dir` to the corresponding `global_step_XXX` folder:
 
 ```bash
-trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}/global_step_120
+trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name}/global_step_120
 ```
 
 #### ✅ Path Tolerance
@@ -201,7 +201,7 @@ If a `config.json` file is **missing** from any `global_step_*/actor/huggingface
 
 ```bash
 trinity convert \
-  --checkpoint-dir ${checkpoint_root_dir}/${project}/${name} \
+  --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name} \
   --base-model-dir /path/to/your/base/model
 ```
 

--- a/docs/sphinx_doc/source/tutorial/trinity_configs.md
+++ b/docs/sphinx_doc/source/tutorial/trinity_configs.md
@@ -77,15 +77,16 @@ ignore_validator_suggestions: false
 
 - `project`: The name of the project.
 - `name`: The name of the current experiment.
+- `group`: Optional experiment group inserted between `<project>` and `<name>` in the checkpoint path, i.e. `<checkpoint_root_dir>/<project>/<group>/<name>/`. Empty by default, in which case it is omitted from the path.
 - `mode`: Running mode of Trinity-RFT. Options include:
   - `both`: Launches both the trainer and explorer (default).
   - `train`: Only launches the trainer.
   - `explore`: Only launches the explorer.
   - `bench`: Used for benchmarking.
   - `colocate`: Only for single GPU scenarios, launches both trainer and explorer on the same GPU.
-- `checkpoint_root_dir`: Root directory where all checkpoints and logs will be saved. Checkpoints for this experiment will be stored in `<checkpoint_root_dir>/<project>/<name>/`.
+- `checkpoint_root_dir`: Root directory where all checkpoints and logs will be saved. Checkpoints for this experiment will be stored in `<checkpoint_root_dir>/<project>/<group>/<name>/`.
 - `continue_from_checkpoint`: If set to `true`, the experiment will continue from the latest checkpoint in the checkpoint path (if any); otherwise, it will rename the current experiment to `<name>_<timestamp>` and start a new experiment. Due to our decoupled design, during recovery from a checkpoint, we can only guarantee that the Trainer's model parameters and its optional auxiliary buffers (`auxiliary_buffers`) are restored to their latest checkpointed states, while the Explorer and Experience Buffer cannot be guaranteed to be restored to the same point in time.
-- `ray_namespace`: Namespace for the modules launched in the current experiment. If not specified, it will be set to `<project>/<name>`.
+- `ray_namespace`: Namespace for the modules launched in the current experiment. If not specified, it will be set to `<project>/<group>/<name>`.
 - `ignore_validator_suggestions`: When set to `false` (the default), the config validator checks GPU memory usage and suggests configuration changes if needed. When set to `true`, the validator skips GPU memory usage check.
 
 ---
@@ -138,8 +139,8 @@ monitor:
 ```
 
 - `monitor_type`: Type of monitoring system. Options:
-  - `wandb`: Logs to [Weights & Biases](https://docs.wandb.ai/quickstart/). Requires logging in and setting `WANDB_API_KEY`. Project and run names match the `project` and `name` fields in global configs.
-  - `tensorboard`: Logs to [TensorBoard](https://www.tensorflow.org/tensorboard). Files are saved under `<checkpoint_root_dir>/<project>/<name>/monitor/tensorboard`.
+  - `wandb`: Logs to [Weights & Biases](https://docs.wandb.ai/quickstart/). Requires logging in and setting `WANDB_API_KEY`. Project and run names match the `project` and `name` fields in global configs; runs are grouped by the `group` field (defaulting to `name` when empty).
+  - `tensorboard`: Logs to [TensorBoard](https://www.tensorflow.org/tensorboard). Files are saved under `<checkpoint_root_dir>/<project>/<group>/<name>/monitor/tensorboard`.
   - `mlflow`: Logs to [MLFlow](https://mlflow.org/). If [MLFlow authentication](https://mlflow.org/docs/latest/ml/auth/) is setup, set `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` as environment variables before running.
 - `monitor_args`: Dictionary of arguments for monitor initialization.
   - For `wandb`:
@@ -149,7 +150,7 @@ monitor:
     - `uri`: The URI of your MLFlow instance. Strongly recommended to set; defaults to `http://localhost:5000`.
     - `username`: Overrides `MLFLOW_TRACKING_USERNAME` if set.
     - `password`: Overrides `MLFLOW_TRACKING_PASSWORD` if set.
-- `enable_ray_timeline`: If `True`, exports a `timeline.json` file to `<checkpoint_root_dir>/<project>/<name>/monitor`. Viewable in Chrome at [chrome://tracing](chrome://tracing).
+- `enable_ray_timeline`: If `True`, exports a `timeline.json` file to `<checkpoint_root_dir>/<project>/<group>/<name>/monitor`. Viewable in Chrome at [chrome://tracing](chrome://tracing).
 
 ---
 
@@ -600,7 +601,7 @@ log:
 ```
 
 - `level`: The logging level (supports `DEBUG`, `INFO`, `WARNING`, `ERROR`).
-- `group_by_node`: Whether to group logs by node IP. If set to `True`, an actor's logs will be save to `<checkpoint_root_dir>/<project>/<name>/log/<node_ip>/<actor_name>.log`, otherwise it will be saved to `<checkpoint_root_dir>/<project>/<name>/log/<actor_name>.log`.
+- `group_by_node`: Whether to group logs by node IP. If set to `True`, an actor's logs will be save to `<checkpoint_root_dir>/<project>/<group>/<name>/log/<node_ip>/<actor_name>.log`, otherwise it will be saved to `<checkpoint_root_dir>/<project>/<group>/<name>/log/<actor_name>.log`.
 
 ---
 

--- a/docs/sphinx_doc/source_zh/tutorial/align_with_verl.md
+++ b/docs/sphinx_doc/source_zh/tutorial/align_with_verl.md
@@ -152,7 +152,7 @@ explorer:
 | `trainer.logger` | `monitor.monitor_type` | 支持选择的类型和（无需设置）`console` |
 | `trainer.project_name` | `project` | - |
 | `trainer.experiment_name` | `name` | - |
-| `trainer.default_local_dir` | `checkpoint_root_dir` | 检查点保存在 `<checkpoint_root_dir>/<project>/<name>/` |
+| `trainer.default_local_dir` | `checkpoint_root_dir` | 检查点保存在 `<checkpoint_root_dir>/<project>/<group>/<name>/` |
 | `trainer.n_gpus_per_node` | `cluster.gpu_per_node` | - |
 | `trainer.nnodes` | `cluster.node_num` | - |
 | `trainer.save_freq` | `trainer.save_interval` | - |
@@ -166,7 +166,7 @@ explorer:
 
 💡 详细说明：
 
-* 如果您想从检查点恢复训练，可以将 `continue_from_checkpoint` 设置为 `True`，训练将从检查点路径 `<checkpoint_root_dir>/<project>/<name>/` 中的最新检查点开始（如果有的话）。
+* 如果您想从检查点恢复训练，可以将 `continue_from_checkpoint` 设置为 `True`，训练将从检查点路径 `<checkpoint_root_dir>/<project>/<group>/<name>/` 中的最新检查点开始（如果有的话）。
 
 
 ## GPU 资源分配

--- a/docs/sphinx_doc/source_zh/tutorial/develop_workflow.md
+++ b/docs/sphinx_doc/source_zh/tutorial/develop_workflow.md
@@ -533,7 +533,7 @@ class Workflow(ABC):
         self.logger = get_logger(__name__)  # 用于运行时监控的内置 logger
 ```
 
-该内置的 logger 会将日志输出到控制台和 `<checkpoint_root_dir>/<project>/<name>/log` 目录下的文件中。这样就可以方便地在训练过程中监控工作流的运行状态。由于所有 Workflow 子类均继承该 logger，因此你可以直接在自定义工作流中使用它来记录关键信息。
+该内置的 logger 会将日志输出到控制台和 `<checkpoint_root_dir>/<project>/<group>/<name>/log` 目录下的文件中。这样就可以方便地在训练过程中监控工作流的运行状态。由于所有 Workflow 子类均继承该 logger，因此你可以直接在自定义工作流中使用它来记录关键信息。
 
 ```python
 class ExampleWorkflow(Workflow):
@@ -549,7 +549,7 @@ class ExampleWorkflow(Workflow):
 由于 Trinity-RFT 会自动创建一组 Workflow Runners 来并行执行 Workflow。每个运行器会将其日志输出到一个单独的日志文件中。日志文件的命名规则为 `explorer_runner_<runner_id>.log`，其中 `<runner_id>` 是工作流运行器的唯一标识符。通过这种设计，你可以独立地追踪正在并行执行的每个工作流实例的运行情况。日志文件的具体组织结构如下：
 
 ```
-<checkpoint_root_dir>/<project>/<name>/log/
+<checkpoint_root_dir>/<project>/<group>/<name>/log/
     ├── explorer_runner_0.log
     ├── explorer_runner_1.log
     ├── explorer_runner_2.log

--- a/docs/sphinx_doc/source_zh/tutorial/example_reasoning_basic.md
+++ b/docs/sphinx_doc/source_zh/tutorial/example_reasoning_basic.md
@@ -120,16 +120,16 @@ trinity run --config examples/grpo_gsm8k/gsm8k.yaml
 
 ## 进阶选项：将检查点转换为 Hugging Face 格式
 
-在运行 Trinity-RFT 进行实验后，系统会自动将训练过程中的检查点（checkpoint）保存到以下路径：
+在运行 Trinity-RFT 进行实验后，系统会自动将训练过程中的检查点（checkpoint）保存到以下路径（其中 `${group}` 段为可选项，当 `group` 为空时省略，默认即 `${project}/${name}`）：
 
 ```
-${checkpoint_root_dir}/${project}/${name}
+${checkpoint_root_dir}/${project}/${group}/${name}
 ```
 
 该目录的结构如下：
 
 ```
-${checkpoint_root_dir}/${project}/${name}
+${checkpoint_root_dir}/${project}/${group}/${name}
 ├── buffer
 │   ├── experience_buffer.jsonl          # 存储训练过程中生成的经验数据
 │   └── explorer_output.db               # Explorer 模块输出的数据库文件
@@ -178,7 +178,7 @@ ${checkpoint_root_dir}/${project}/${name}
 将 `--checkpoint-dir` 指向项目根目录（即包含多个 `global_step_*` 子目录的路径），工具会**自动递归查找所有 `global_step_*` 目录**，并对每个检查点执行转换。
 
 ```bash
-trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}
+trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name}
 ```
 
 该命令会：
@@ -190,7 +190,7 @@ trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}
 如果只想转换某一个特定训练步的模型，可直接将 `--checkpoint-dir` 指向对应的 `global_step_XXX` 文件夹：
 
 ```bash
-trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}/global_step_120
+trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name}/global_step_120
 ```
 
 #### ✅ 路径容错
@@ -202,7 +202,7 @@ trinity convert --checkpoint-dir ${checkpoint_root_dir}/${project}/${name}/globa
 
 ```bash
 trinity convert \
-  --checkpoint-dir ${checkpoint_root_dir}/${project}/${name} \
+  --checkpoint-dir ${checkpoint_root_dir}/${project}/${group}/${name} \
   --base-model-dir /path/to/your/base/model
 ```
 

--- a/docs/sphinx_doc/source_zh/tutorial/trinity_configs.md
+++ b/docs/sphinx_doc/source_zh/tutorial/trinity_configs.md
@@ -77,15 +77,16 @@ ignore_validator_suggestions: false
 
 - `project`: 项目名称。
 - `name`: 当前实验的名称。
+- `group`: 可选的实验分组，插入到检查点路径中 `<project>` 与 `<name>` 之间，即 `<checkpoint_root_dir>/<project>/<group>/<name>/`。默认为空，此时从路径中省略。
 - `mode`: Trinity-RFT 的运行模式。选项包括：
   - `both`: 同时启动 trainer 和 explorer（默认）。
   - `train`: 仅启动 trainer。
   - `explore`: 仅启动 explorer。
   - `bench`: 用于 benchmark 测试。
   - `colocate`: 仅适用于单 GPU 场景，在同一 GPU 上启动 trainer 和 explorer。
-- `checkpoint_root_dir`: 所有检查点和日志的根目录。该实验的检查点将存储在 `<checkpoint_root_dir>/<project>/<name>/` 路径下。
+- `checkpoint_root_dir`: 所有检查点和日志的根目录。该实验的检查点将存储在 `<checkpoint_root_dir>/<project>/<group>/<name>/` 路径下。
 - `continue_from_checkpoint`: 若设置为 `true`，实验将从检查点路径中的最新检查点继续；否则，会将当前实验重命名为 `<name>_<timestamp>` 并启动新实验。由于我们的分离式设计，从检查点恢复的时候，我们只能保证Trainer的模型参数以及其使用的可选缓冲区（`auxiliary_buffers`）可以恢复到最新检查点的状态，而Explorer和Experience Buffer不能保证恢复到同一时点。
-- `ray_namespace`: 当前实验中启动模块的命名空间。若未指定，则默认为 `<project>/<name>`。
+- `ray_namespace`: 当前实验中启动模块的命名空间。若未指定，则默认为 `<project>/<group>/<name>`。
 - `ignore_validator_suggestions`：如果设置为`false`，配置验证器将检查GPU内存使用情况，并提出配置更改建议。如果设置为`true`，验证器将不检查GPU内存使用情况。默认值为`false`。
 
 ---
@@ -138,8 +139,8 @@ monitor:
 ```
 
 - `monitor_type`: 监控系统类型。选项：
-  - `wandb`: 记录到 [Weights & Biases](https://docs.wandb.ai/quickstart/)。需要登录并设置 `WANDB_API_KEY`。项目和运行名称与全局配置中的 `project` 和 `name` 字段一致。
-  - `tensorboard`: 记录到 [TensorBoard](https://www.tensorflow.org/tensorboard)。文件保存在 `<checkpoint_root_dir>/<project>/<name>/monitor/tensorboard` 下。
+  - `wandb`: 记录到 [Weights & Biases](https://docs.wandb.ai/quickstart/)。需要登录并设置 `WANDB_API_KEY`。项目和运行名称与全局配置中的 `project` 和 `name` 字段一致；运行按 `group` 字段分组（为空时默认使用 `name`）。
+  - `tensorboard`: 记录到 [TensorBoard](https://www.tensorflow.org/tensorboard)。文件保存在 `<checkpoint_root_dir>/<project>/<group>/<name>/monitor/tensorboard` 下。
   - `mlflow`: 记录到 [MLFlow](https://mlflow.org/)。如果设置了 [MLFlow 认证](https://mlflow.org/docs/latest/ml/auth/)，请在运行前将 `MLFLOW_TRACKING_USERNAME` 和 `MLFLOW_TRACKING_PASSWORD` 设置为环境变量。
 - `monitor_args`: 初始化监控器的参数字典。
   - 对于 `wandb`：
@@ -149,7 +150,7 @@ monitor:
     - `uri`: MLFlow 实例的 URI。强烈建议设置；默认为 `http://localhost:5000`。
     - `username`: 若设置，将覆盖 `MLFLOW_TRACKING_USERNAME`。
     - `password`: 若设置，将覆盖 `MLFLOW_TRACKING_PASSWORD`。
-- `enable_ray_timeline`: 若为 `True`，将导出一个 `timeline.json` 文件到 `<checkpoint_root_dir>/<project>/<name>/monitor`。可在 Chrome 浏览器中访问 [chrome://tracing](chrome://tracing) 查看。
+- `enable_ray_timeline`: 若为 `True`，将导出一个 `timeline.json` 文件到 `<checkpoint_root_dir>/<project>/<group>/<name>/monitor`。可在 Chrome 浏览器中访问 [chrome://tracing](chrome://tracing) 查看。
 
 ---
 
@@ -597,7 +598,7 @@ log:
 ```
 
 - `level`: 日志级别（支持 `DEBUG`、`INFO`、`WARNING`、`ERROR`）。
-- `group_by_node`: 是否按节点 IP 分组日志。若设为 `True`，actor 的日志将保存到 `<checkpoint_root_dir>/<project>/<name>/log/<node_ip>/<actor_name>.log`，否则保存到 `<checkpoint_root_dir>/<project>/<name>/log/<actor_name>.log`。
+- `group_by_node`: 是否按节点 IP 分组日志。若设为 `True`，actor 的日志将保存到 `<checkpoint_root_dir>/<project>/<group>/<name>/log/<node_ip>/<actor_name>.log`，否则保存到 `<checkpoint_root_dir>/<project>/<group>/<name>/log/<actor_name>.log`。
 
 ---
 

--- a/trinity/cli/launcher.py
+++ b/trinity/cli/launcher.py
@@ -358,7 +358,7 @@ def run(
     cfg = load_config(config)
 
     if dlc:
-        cluster_namespace = f"{cfg.project}-{cfg.name}"
+        cluster_namespace = "-".join(p for p in [cfg.project, cfg.group, cfg.name] if p)
         cfg.cluster.ray_address = setup_ray_cluster(namespace=cluster_namespace)
 
     if not is_running():
@@ -369,9 +369,7 @@ def run(
             from trinity.manager.state_manager import StateManager
             from trinity.trainer.verl.utils import get_latest_hf_checkpoint_path
 
-            state_manager = StateManager(
-                path=os.path.join(cfg.checkpoint_root_dir, cfg.project, cfg.name)
-            )
+            state_manager = StateManager(path=cfg.get_checkpoint_job_dir())
             latest_stage = state_manager.load_stage().get("latest_stage", 0)
             prev_stage_checkpoint = None
             for i, stage_config in enumerate(cfg):

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -262,7 +262,7 @@ class TasksetConfig:
     total_epochs: int = 1  # automatically set
     # ! DO NOT SET, automatically set from buffer.total_steps
     total_steps: Optional[int] = None  # automatically set
-    # ! DO NOT SET, automatically set form ray_namespace
+    # ! DO NOT SET, automatically set from ray_namespace
     ray_namespace: Optional[str] = None
 
     def to_storage_config(self) -> StorageConfig:
@@ -329,7 +329,7 @@ class ExperienceBufferConfig:
     total_epochs: int = 1  # automatically set
     # ! DO NOT SET, automatically set from buffer.total_steps
     total_steps: Optional[int] = None  # automatically set
-    # ! DO NOT SET, automatically set form ray_namespace
+    # ! DO NOT SET, automatically set from ray_namespace
     ray_namespace: Optional[str] = None
 
     def to_storage_config(self) -> StorageConfig:
@@ -863,7 +863,7 @@ class LogConfig:
 
     level: str = "INFO"  # default log level (DEBUG, INFO, WARNING, ERROR)
     group_by_node: bool = False  # whether to group logs by node IP in Ray cluster
-    # ! DO NOT SET, automatically generated as <checkpoint_root_dir>/<project>/<name>/log
+    # ! DO NOT SET, automatically generated as <checkpoint_root_dir>/<project>/<group>/<name>/log
     save_dir: str = ""
 
 
@@ -890,9 +890,9 @@ class Config:
     name: str = "rft"
     # the root dir for checkpoints
     checkpoint_root_dir: str = ""
-    # ! DO NOT SET, automatically generated as `checkpoint_root_dir/project/name`
+    # ! DO NOT SET, automatically generated as `checkpoint_root_dir/project/group/name`
     checkpoint_job_dir: str = ""
-    # If not set, automatically generated as f"{config.project}-{config.name}"
+    # If not set, automatically generated as "{project}/{group}/{name}" (empty segments omitted)
     ray_namespace: str = ""
     # whether to continue training from the last checkpoint in checkpoint_job_dir (if any)
     continue_from_checkpoint: bool = True

--- a/trinity/common/config_validator.py
+++ b/trinity/common/config_validator.py
@@ -96,7 +96,7 @@ class GlobalConfigValidator(ConfigValidator):
         # prepare for the checkpoint directory
         if not os.path.isabs(config.checkpoint_root_dir):
             config.checkpoint_root_dir = os.path.join(os.getcwd(), config.checkpoint_root_dir)
-        # create a job dir at checkpoint_root_dir/project/name
+        # create a job dir at checkpoint_root_dir/project/group/name
         config.checkpoint_job_dir = config.get_checkpoint_job_dir()
         # rename the experiment when necessary
         if not config.continue_from_checkpoint and (
@@ -147,7 +147,9 @@ class RayClusterConfigValidator(ConfigValidator):
         """
         # set namespace
         if config.ray_namespace is None or len(config.ray_namespace) == 0:
-            config.ray_namespace = f"{config.project}/{config.name}"
+            config.ray_namespace = "/".join(
+                p for p in [config.project, config.group, config.name] if p
+            )
 
         if config.model.tinker.enable or config.model.external_model.enable:
             return
@@ -887,7 +889,7 @@ class MonitorConfigValidator(ConfigValidator):
         if monitor_cls is None:
             raise ValueError(f"Invalid monitor type: {config.monitor.monitor_type}")
         set_if_none(config.monitor, "monitor_args", monitor_cls.default_args())
-        # create a job dir in <checkpoint_root_dir>/<project>/<name>/monitor
+        # create a job dir in <checkpoint_root_dir>/<project>/<group>/<name>/monitor
         config.monitor.cache_dir = os.path.join(config.checkpoint_job_dir, "monitor")
         try:
             os.makedirs(config.monitor.cache_dir, exist_ok=True)
@@ -937,7 +939,7 @@ class BufferConfigValidator(ConfigValidator):
                 config.buffer.batch_size * config.algorithm.repeat_times
             )
 
-        # create buffer.cache_dir at <checkpoint_root_dir>/<project>/<name>/buffer
+        # create buffer.cache_dir at <checkpoint_root_dir>/<project>/<group>/<name>/buffer
         config.buffer.cache_dir = os.path.abspath(os.path.join(config.checkpoint_job_dir, "buffer"))
         try:
             os.makedirs(config.buffer.cache_dir, exist_ok=True)


### PR DESCRIPTION
`group` is already part of the checkpoint path
(`checkpoint_root_dir/project/group/name`) but was missing from several
derived paths and from the docs/comments. This makes it consistent
everywhere, with no behavior change when `group` is unset (empty-safe joins).

**Code**
- `ray_namespace` and DLC `cluster_namespace` now include `group`
- stages `StateManager` path reuses `get_checkpoint_job_dir()` (previously dropped `group`)
- fix stale comments in config.py / config_validator.py (missing group, `ray_namespace` separator, `form`->`from` typo)

**Docs (en + zh)**
- document the `group` field and wandb run grouping
- reflect `group` in all checkpoint / log / monitor / namespace path descriptions
