### PR TITLE
fix(example): fix dapo-math reward issue

### DIFF
--- a/benchmark/plugins/guru_math/reward.py
+++ b/benchmark/plugins/guru_math/reward.py
@@ -16,7 +16,7 @@ class NaiveDapoRewardFn(MathBoxedRewardFn):
     ) -> dict[str, float]:
         from trinity.common.rewards.naive_dapo_score import compute_score
 
-        score = compute_score(response, truth)  # type: ignore
+        score, _ = compute_score(response, truth)  # type: ignore
         return {"accuracy": score, "format_score": 0}
 
 

--- a/examples/dapo_math/dapo.yaml
+++ b/examples/dapo_math/dapo.yaml
@@ -37,7 +37,7 @@ buffer:
       format:
         prompt_key: 'prompt'
         response_key: 'solution'
-        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.'
+        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.'
       rollout_args:
         temperature: 1.0
         logprobs: 0
@@ -57,7 +57,7 @@ buffer:
       format:
         prompt_key: 'question'
         response_key: 'answer'
-        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.'
+        system_prompt: 'Solve the following math problem step by step. The last line of your response should be of the form Answer: \\boxed{$Answer} where $Answer is the answer to the problem.'
       rollout_args:
         temperature: 1.0
         top_p: 0.7

--- a/trinity/common/rewards/dapo_reward.py
+++ b/trinity/common/rewards/dapo_reward.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Reward Function with Overlong Reward Shaping described in DAPO (https://arxiv.org/pdf/2503.14476)"""
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -37,7 +37,7 @@ class MathDAPORewardFn(RewardFn):
         response_token: torch.Tensor,
         truth: str,
         **kwargs,
-    ) -> Tuple[dict, str]:
+    ) -> dict[str, float]:
         """Compute DAPO reward components for one response.
 
         Args:
@@ -47,9 +47,8 @@ class MathDAPORewardFn(RewardFn):
             **kwargs: Extra arguments for compatibility with reward API.
 
         Returns:
-            Tuple[dict, str]: (metrics dict, extracted_answer)
+            dict[str, float]: Reward components containing accuracy and format_score.
         """
-        # Compute correctness and extract answer
         score, extracted_answer = compute_score(response, truth)
         # DAPO paper (Sec. 2.4): +1 / -1 rule-based outcome reward
         accuracy_score = 1.0 if score >= 0.5 else -1.0
@@ -59,12 +58,15 @@ class MathDAPORewardFn(RewardFn):
         if self.enable_overlong_penalty:
             format_score = self.compute_overlong_penalty(response_token)
 
-        metrics = {
+        info = kwargs.get("info")
+        if info is not None:
+            info["ground_truth"] = truth
+            info["extracted_answer"] = extracted_answer
+
+        return {
             "accuracy": accuracy_score,
             "format_score": format_score,
         }
-
-        return metrics, extracted_answer
 
     def compute_overlong_penalty(self, response_token):
         """Compute soft/hard penalty for long responses.

--- a/trinity/common/rewards/dapo_reward.py
+++ b/trinity/common/rewards/dapo_reward.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Reward Function with Overlong Reward Shaping described in DAPO (https://arxiv.org/pdf/2503.14476)"""
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 
@@ -37,7 +37,7 @@ class MathDAPORewardFn(RewardFn):
         response_token: torch.Tensor,
         truth: str,
         **kwargs,
-    ) -> dict[str, float]:
+    ) -> Tuple[dict, str]:
         """Compute DAPO reward components for one response.
 
         Args:
@@ -47,21 +47,24 @@ class MathDAPORewardFn(RewardFn):
             **kwargs: Extra arguments for compatibility with reward API.
 
         Returns:
-            dict[str, float]: Reward components containing accuracy and format_score.
+            Tuple[dict, str]: (metrics dict, extracted_answer)
         """
-        correct = compute_score(response, truth) >= 0.5
+        # Compute correctness and extract answer
+        score, extracted_answer = compute_score(response, truth)
         # DAPO paper (Sec. 2.4): +1 / -1 rule-based outcome reward
-        accuracy_score = 1.0 if correct else -1.0
+        accuracy_score = 1.0 if score >= 0.5 else -1.0
 
         format_score = 0.0
 
         if self.enable_overlong_penalty:
             format_score = self.compute_overlong_penalty(response_token)
 
-        return {
+        metrics = {
             "accuracy": accuracy_score,
             "format_score": format_score,
         }
+
+        return metrics, extracted_answer
 
     def compute_overlong_penalty(self, response_token):
         """Compute soft/hard penalty for long responses.

--- a/trinity/common/rewards/naive_dapo_score.py
+++ b/trinity/common/rewards/naive_dapo_score.py
@@ -8,6 +8,7 @@ import math
 import os
 import re
 import resource
+from typing import Tuple
 
 import sympy
 from pylatexenc import latex2text
@@ -466,7 +467,7 @@ def match_answer(response):
     return is_matched, response
 
 
-def compute_score(solution_str: str, ground_truth: str) -> float:
+def compute_score(solution_str: str, ground_truth: str) -> Tuple[float, str]:
     """Compute the reward score for a solution. This draws heavily from the LLM-as-judge and PRIME reward functions
 
     Args:
@@ -475,7 +476,7 @@ def compute_score(solution_str: str, ground_truth: str) -> float:
         extra_info: dict with additional info for the score computation
 
     Returns:
-        Reward score (1.0 for correct, 0.0 for incorrect)
+        Tuple[float, str]: (reward score 1.0 or 0.0, extracted_model_output)
     """
     from verl.utils.reward_score.prime_math.grader import math_equal
 
@@ -485,6 +486,10 @@ def compute_score(solution_str: str, ground_truth: str) -> float:
 
     # Extract answer from generated output
     is_matched, extracted_model_output = match_answer(model_output)
+
+    # If not matched, truncate the output for debugging
+    if not is_matched and len(extracted_model_output) > 20:
+        extracted_model_output = extracted_model_output[:20] + "(... output is truncated.)"
 
     # TWK NOTE: WE REMOVED THE RESPONSE TRUNCATION FROM math_dapo.compute_score
 
@@ -505,4 +510,4 @@ def compute_score(solution_str: str, ground_truth: str) -> float:
         except Exception:
             correct = False
 
-    return 1.0 if correct else 0.0
+    return 1.0 if correct else 0.0, extracted_model_output

--- a/trinity/common/workflows/customized_math_workflows.py
+++ b/trinity/common/workflows/customized_math_workflows.py
@@ -68,12 +68,15 @@ class MathBoxedWorkflow(SimpleWorkflow):
             responses = self.model.generate([prompt_text], **self.rollout_args)
 
         for i, response in enumerate(responses):
-            reward_dict, extracted_answer = self.reward_fn(  # type: ignore [misc]
+            if response.info is None:
+                response.info = {}
+            reward_dict = self.reward_fn(  # type: ignore [misc]
                 response=response.response_text,  # type: ignore [arg-type]
                 truth=self.truth,
                 with_think=self.with_think,
                 format_score_coef=self.format_score_coef,
                 response_token=response.tokens[response.prompt_length :],
+                info=response.info,
             )
 
             if response.metrics is None:
@@ -82,13 +85,6 @@ class MathBoxedWorkflow(SimpleWorkflow):
             reward = sum(reward_dict.values())
             response.reward = reward
             response.eid.run = i + self.run_id_base
-
-            # Save ground_truth and extracted_answer to info field for debugging
-            if response.info is None:
-                response.info = {}
-            response.info["ground_truth"] = self.truth
-            response.info["extracted_answer"] = extracted_answer
-
             if (
                 response.truncate_status == "response_truncated"
                 and response.action_mask is not None
@@ -122,12 +118,15 @@ class AsyncMathBoxedWorkflow(MathBoxedWorkflow):
             responses = await self.model.generate_async([prompt_text], **self.rollout_args)
 
         for i, response in enumerate(responses):
-            reward_dict, extracted_answer = self.reward_fn(  # type: ignore [misc]
+            if response.info is None:
+                response.info = {}
+            reward_dict = self.reward_fn(  # type: ignore [misc]
                 response=response.response_text,  # type: ignore [arg-type]
                 truth=self.truth,
                 with_think=self.with_think,
                 format_score_coef=self.format_score_coef,
                 response_token=response.tokens[response.prompt_length :],
+                info=response.info,
             )
 
             if response.metrics is None:
@@ -136,13 +135,6 @@ class AsyncMathBoxedWorkflow(MathBoxedWorkflow):
             reward = sum(reward_dict.values())
             response.reward = reward
             response.eid.run = i + self.run_id_base
-
-            # Save ground_truth and extracted_answer to info field for debugging
-            if response.info is None:
-                response.info = {}
-            response.info["ground_truth"] = self.truth
-            response.info["extracted_answer"] = extracted_answer
-
             if (
                 response.truncate_status == "response_truncated"
                 and response.action_mask is not None

--- a/trinity/common/workflows/customized_math_workflows.py
+++ b/trinity/common/workflows/customized_math_workflows.py
@@ -68,7 +68,7 @@ class MathBoxedWorkflow(SimpleWorkflow):
             responses = self.model.generate([prompt_text], **self.rollout_args)
 
         for i, response in enumerate(responses):
-            reward_dict = self.reward_fn(  # type: ignore [misc]
+            reward_dict, extracted_answer = self.reward_fn(  # type: ignore [misc]
                 response=response.response_text,  # type: ignore [arg-type]
                 truth=self.truth,
                 with_think=self.with_think,
@@ -82,6 +82,13 @@ class MathBoxedWorkflow(SimpleWorkflow):
             reward = sum(reward_dict.values())
             response.reward = reward
             response.eid.run = i + self.run_id_base
+
+            # Save ground_truth and extracted_answer to info field for debugging
+            if response.info is None:
+                response.info = {}
+            response.info["ground_truth"] = self.truth
+            response.info["extracted_answer"] = extracted_answer
+
             if (
                 response.truncate_status == "response_truncated"
                 and response.action_mask is not None
@@ -115,7 +122,7 @@ class AsyncMathBoxedWorkflow(MathBoxedWorkflow):
             responses = await self.model.generate_async([prompt_text], **self.rollout_args)
 
         for i, response in enumerate(responses):
-            reward_dict = self.reward_fn(  # type: ignore [misc]
+            reward_dict, extracted_answer = self.reward_fn(  # type: ignore [misc]
                 response=response.response_text,  # type: ignore [arg-type]
                 truth=self.truth,
                 with_think=self.with_think,
@@ -129,6 +136,13 @@ class AsyncMathBoxedWorkflow(MathBoxedWorkflow):
             reward = sum(reward_dict.values())
             response.reward = reward
             response.eid.run = i + self.run_id_base
+
+            # Save ground_truth and extracted_answer to info field for debugging
+            if response.info is None:
+                response.info = {}
+            response.info["ground_truth"] = self.truth
+            response.info["extracted_answer"] = extracted_answer
+
             if (
                 response.truncate_status == "response_truncated"
                 and response.action_mask is not None


### PR DESCRIPTION
## Description

[Please describe the background, purpose, changes made, and how to test this PR]

### Background
  
  The DAPO math reward function previously suffered from incorrect reward computation due to two issues:
  1. The system_prompt instructed the model to answer in the form Answer: $Answer, but the parser expected \boxed{$Answer}, leading to many correct responses being scored
  as incorrect.
  2. There was no way to inspect what the parser actually extracted from the model's output, making it hard to debug reward mismatches.

### Purpose

  Fix the dapo-math reward computation so that scores correctly reflect model correctness, and surface enough metadata to debug future reward issues.

### Changes Made

  - examples/dapo_math/dapo.yaml: Updated system_prompt for both train and eval datasets to instruct the model to wrap answers in \boxed{...}, matching the parser's
  expectation.
  - trinity/common/rewards/naive_dapo_score.py: compute_score now returns Tuple[float, str] — the score plus the extracted model answer. Unmatched outputs are truncated to
  20 chars for compact debugging.
  - trinity/common/rewards/dapo_reward.py: MathDAPORewardFn.__call__ propagates the extracted answer alongside the metrics dict.
  - trinity/common/workflows/customized_math_workflows.py: Both sync and async MathBoxedWorkflow save ground_truth and extracted_answer into response.info for downstream
  inspection.

### How to Test
  
  1. Run the dapo-math example end-to-end:
  trinity run --config examples/dapo_math/dapo.yaml
  2. Verify that the rollout reward distribution is no longer dominated by -1.0 (i.e., correct responses are now properly credited).
  3. Inspect response.info in the experience buffer and confirm both ground_truth and extracted_answer fields are populated.


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
