### PR TITLE
explorer: fix glibc getenv SIGSEGV when creating runners at startup

### DIFF
--- a/docs/sphinx_doc/source/tutorial/trinity_configs.md
+++ b/docs/sphinx_doc/source/tutorial/trinity_configs.md
@@ -404,6 +404,8 @@ Controls the rollout models and workflow execution.
 explorer:
   name: explorer
   runner_per_model: 8
+  runner_prepare_concurrency: 8
+  runner_prepare_max_retries: 2
   concurrent_mode: sequential
   max_repeat_times_per_runner: null
   max_timeout: 900
@@ -434,6 +436,8 @@ explorer:
 
 - `name`: Name of the explorer. This name will be used as the Ray actor's name, so it must be unique.
 - `runner_per_model`: Number of parallel workflow runners per each rollout model.
+- `runner_prepare_concurrency`: Max number of runners prepared concurrently at startup. Creating all runners at once makes many workers call `getenv()` simultaneously, which can race with library `setenv()` and segfault in glibc; this caps the concurrency (total runner count is unchanged).
+- `runner_prepare_max_retries`: How many times to retry a runner's prepare on a transient startup crash (e.g. the glibc getenv race). Retries happen within the same concurrency slot with backoff, so they never exceed `runner_prepare_concurrency`.
 - `concurrent_mode`: Concurrency mode for executing a set of tasks (e.g., multiple repeats of a task in GRPO algorithm). Supported options:
   - `sequential`: Executes tasks sequentially (default). One task is executed at a time, waiting for its completion before executing the next. This requires the least from the workflow implementation but has the worst throughput.
   - `asynchronous`: Executes tasks asynchronously. All tasks are submitted at once, and results are collected as they complete. Requires the workflow to correctly implement asynchronous call interfaces and have no shared state between workflows to avoid race conditions. Throughput is better than sequential execution, but the performance depends on the workflow implementation.

--- a/docs/sphinx_doc/source_zh/tutorial/trinity_configs.md
+++ b/docs/sphinx_doc/source_zh/tutorial/trinity_configs.md
@@ -401,6 +401,8 @@ buffer:
 explorer:
   name: explorer
   runner_per_model: 8
+  runner_prepare_concurrency: 8
+  runner_prepare_max_retries: 2
   concurrent_mode: sequential
   max_repeat_times_per_runner: null
   max_timeout: 900
@@ -431,6 +433,8 @@ explorer:
 
 - `name`: explorer 的名称。该名称将用作 Ray actor 的名称，因此必须唯一。
 - `runner_per_model`: 每个推理引擎实例所服务的 WorkflowRunner 数量。
+- `runner_prepare_concurrency`: 启动时并发创建 runner 的最大数量。一次性创建所有 runner 会让大量 worker 同时调用 `getenv()`，可能与库的 `setenv()` 竞争导致 glibc 段错误；该参数限制并发数（runner 总数不变）。
+- `runner_prepare_max_retries`: 单个 runner 的 prepare 在偶发启动崩溃（例如 glibc getenv 竞争）时的重试次数。重试在同一并发槽内进行并带退避，因此不会超过 `runner_prepare_concurrency`。
 - `concurrent_mode`: 执行一组任务（例如 GRPO 算法中对一个任务的多次重复执行）的并发模式。支持如下选项：
   - `sequential`: 顺序执行（默认）。每次执行一个任务，等待其完成后再执行下一个任务。对 workflow 的实现要求最低，但吞吐量也最差。
   - `asynchronous`: 异步执行。使用异步模式一次性提交所有任务，并在任务完成后收集结果。要求 workflow 正确地实现了异步调用接口，并且 workflow 之间没有共享状态，以避免竞态条件。吞吐量优于顺序执行，但具体性能受限于 workflow 的实现。

--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -716,6 +716,8 @@ class ExplorerConfig:
     # for workflow runner
     # number of workflow runners.
     runner_per_model: int = 8  # number of runners per each rollout model
+    runner_prepare_concurrency: int = 8  # cap concurrent prepares (glibc getenv race)
+    runner_prepare_max_retries: int = 2  # retry prepare on transient crash
     max_timeout: int = 1800  # wait each task for 30 minutes at most
     max_retry_times: int = 2  # retry each task for 2 times if it fails or timeout
     env_vars: dict = field(default_factory=dict)  # environment variables for workflow runner

--- a/trinity/explorer/scheduler.py
+++ b/trinity/explorer/scheduler.py
@@ -490,7 +490,25 @@ class Scheduler:
         if self.running:
             return
         self.running = True
-        await asyncio.gather(*[self._create_runner(i) for i in range(self.runner_num)])
+        # bounded-concurrency runner prepare with in-slot retry (avoids glibc getenv races)
+        _sem = asyncio.Semaphore(max(1, self.config.explorer.runner_prepare_concurrency))
+        _retries = max(0, self.config.explorer.runner_prepare_max_retries)
+
+        async def _create_limited(i: int) -> None:
+            async with _sem:
+                for attempt in range(_retries + 1):
+                    try:
+                        await self._create_runner(i)
+                        return
+                    except Exception as e:
+                        if attempt == _retries:
+                            raise
+                        self.logger.warning(
+                            f"Runner {i} prepare failed ({attempt + 1}/{_retries + 1}), retrying: {e}"
+                        )
+                        await asyncio.sleep(2.0 * (attempt + 1))
+
+        await asyncio.gather(*[_create_limited(i) for i in range(self.runner_num)])
         self.scheduler_task = asyncio.create_task(self._scheduler_loop())
         ready_refs = [runner.runner.__ray_ready__.remote() for runner in self.runners.values()]
         await asyncio.gather(*ready_refs)


### PR DESCRIPTION
`scheduler.start()` creates all runners at once via `asyncio.gather`, so on large setups hundreds of workers call `getenv()` concurrently. This races with library `setenv()` and segfaults in glibc (getenv takes no lock while setenv reallocs `environ`).

Crash during runner creation (`_create_runner` → `runner.prepare()`):

```
(pid=24241) *** SIGSEGV received at time=... on cpu 59 ***
(pid=24241) PC: @  0x7fe6ace44c1d  (unknown)  getenv
Fatal Python error: Segmentation fault
...
ray.exceptions.ActorDiedError: The actor died unexpectedly before finishing this task.
    class_name: WorkflowRunner
    namespace: bench-codeflow-frozen_lake_obscure-pack1-seed1
  File ".../trinity/explorer/scheduler.py", line 587, in start
    await asyncio.gather(*[self._create_runner(i) for i in range(self.runner_num)])
  File ".../trinity/explorer/scheduler.py", line 381, in _create_runner
    await runner.prepare()
```

**Fix:** cap concurrent runner prepares (`explorer.runner_prepare_concurrency`, default 8) and retry within the same slot on transient crashes (`explorer.runner_prepare_max_retries`, default 2). Total runner count is unchanged.