### PR TITLE
Optimize viewer and add tests

### DIFF
--- a/docs/sphinx_doc/source/tutorial/faq.md
+++ b/docs/sphinx_doc/source/tutorial/faq.md
@@ -157,13 +157,14 @@ Please refer to {ref}`Workflow Development Guide <Workflows>` section for detail
 
 **A:** You can use the `trinity view` command to launch a Streamlit-based viewer that lets you browse the experience data produced during exploration, including the prompt, response, reward, metrics, and token-level details (with per-token log-probs).
 
-This requires the experience pipeline to actually write a SQL database. Make sure your config has the following set:
+This requires the experience pipeline to actually write a SQL database. Just enable `save_input` — when `input_save_path` is left unset, the pipeline automatically writes to a SQLite database at `<checkpoint_job_dir>/buffer/explorer_output.db`:
 
 ```yaml
 data_processor:
   experience_pipeline:
     save_input: true
-    input_save_path: sqlite:////path/to/your/debug_buffer.db
+    # input_save_path is optional; defaults to
+    # <checkpoint_job_dir>/buffer/explorer_output.db
 ```
 
 Then run the viewer, pointing it at the config file (the database URL, table name, and tokenizer are inferred automatically):

--- a/docs/sphinx_doc/source/tutorial/faq.md
+++ b/docs/sphinx_doc/source/tutorial/faq.md
@@ -151,6 +151,35 @@ trinity run --config grpo_gsm8k/gsm8k.yaml 2>&1 | tee debug.log
 
 Please refer to {ref}`Workflow Development Guide <Workflows>` section for details.
 
+---
+
+**Q:** How to inspect the experiences generated during training?
+
+**A:** You can use the `trinity view` command to launch a Streamlit-based viewer that lets you browse the experience data produced during exploration, including the prompt, response, reward, metrics, and token-level details (with per-token log-probs).
+
+This requires the experience pipeline to actually write a SQL database. Make sure your config has the following set:
+
+```yaml
+data_processor:
+  experience_pipeline:
+    save_input: true
+    input_save_path: sqlite:////path/to/your/debug_buffer.db
+```
+
+Then run the viewer, pointing it at the config file (the database URL, table name, and tokenizer are inferred automatically):
+
+```bash
+trinity view --config examples/grpo_gsm8k/gsm8k.yaml --port 8502
+```
+
+You can also point directly at the database file and specify the components manually (the table name produced by the experience pipeline is `pipeline_input`):
+
+```bash
+trinity view --url /path/to/debug_buffer.db --table pipeline_input --tokenizer /path/to/model --port 8502
+```
+
+Note: `--url` accepts either a DB URL (`sqlite:////abs/path.db`) or a plain path to a `.db` file (relative or absolute), which is converted to a sqlite URL automatically. Explicit CLI arguments override values inferred from `--config`.
+
 
 ## Part 4: Other Questions
 **Q:** What's the purpose of `buffer.trainer_input.experience_buffer.path`?

--- a/docs/sphinx_doc/source_zh/tutorial/faq.md
+++ b/docs/sphinx_doc/source_zh/tutorial/faq.md
@@ -144,6 +144,36 @@ trinity run --config grpo_gsm8k/gsm8k.yaml 2>&1 | tee debug.log
 
 详细说明见 {ref}`工作流开发指南 <Workflows>`。
 
+---
+
+**Q:** 如何查看训练过程中产生的 Experience 数据？
+
+**A:** 可以使用 `trinity view` 命令启动一个基于 Streamlit 的可视化界面，浏览探索阶段产生的 experience 数据，包括 prompt、response、reward、metrics 以及 token 级别（每个 token 的 log-prob）的详细信息。
+
+该功能要求 experience pipeline 实际写入 SQL 数据库，请确保配置中已设置：
+
+```yaml
+data_processor:
+  experience_pipeline:
+    save_input: true
+    input_save_path: sqlite:////path/to/your/debug_buffer.db
+```
+
+然后指向配置文件启动查看器（数据库 URL、表名、tokenizer 会自动推导）：
+
+```bash
+trinity view --config examples/grpo_gsm8k/gsm8k.yaml --port 8502
+```
+
+也可以直接指向数据库文件并手动指定各组件（experience pipeline 产生的表名为 `pipeline_input`）：
+
+```bash
+trinity view --url /path/to/debug_buffer.db --table pipeline_input --tokenizer /path/to/model --port 8502
+```
+
+注意：`--url` 既支持 DB URL（如 `sqlite:////abs/path.db`），也支持直接给出 `.db` 文件路径（相对或绝对均可），会自动转换为 sqlite URL。显式给出的 CLI 参数会覆盖从 `--config` 推导出的值。
+
+
 ## 第四部分：其他问题
 
 **Q:** `buffer.trainer_input.experience_buffer.path` 有什么作用？

--- a/docs/sphinx_doc/source_zh/tutorial/faq.md
+++ b/docs/sphinx_doc/source_zh/tutorial/faq.md
@@ -150,13 +150,14 @@ trinity run --config grpo_gsm8k/gsm8k.yaml 2>&1 | tee debug.log
 
 **A:** 可以使用 `trinity view` 命令启动一个基于 Streamlit 的可视化界面，浏览探索阶段产生的 experience 数据，包括 prompt、response、reward、metrics 以及 token 级别（每个 token 的 log-prob）的详细信息。
 
-该功能要求 experience pipeline 实际写入 SQL 数据库，请确保配置中已设置：
+该功能要求 experience pipeline 实际写入 SQL 数据库。只需开启 `save_input`——当未设置 `input_save_path` 时，pipeline 会自动写入到 `<checkpoint_job_dir>/buffer/explorer_output.db`：
 
 ```yaml
 data_processor:
   experience_pipeline:
     save_input: true
-    input_save_path: sqlite:////path/to/your/debug_buffer.db
+    # input_save_path 可选，默认为
+    # <checkpoint_job_dir>/buffer/explorer_output.db
 ```
 
 然后指向配置文件启动查看器（数据库 URL、表名、tokenizer 会自动推导）：

--- a/tests/cli/view_test.py
+++ b/tests/cli/view_test.py
@@ -1,0 +1,266 @@
+"""Tests for the ``trinity view`` command and its config-resolution helpers.
+
+Covers the behaviours added/changed for the viewer CLI:
+- ``--url`` accepting a plain ``.db`` file path (relative/absolute) and a DB URL.
+- ``--config`` resolving the database URL, table name and tokenizer from a config.
+- the experience-pipeline default ``input_save_path`` living in the pipeline
+  (``default_input_save_path``) rather than a config validator.
+- the rename edge-case warning.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import typer
+from typer.testing import CliRunner
+
+from trinity.cli.view import (
+    _resolve_db_url,
+    _resolve_from_config,
+    _warn_if_renamed,
+    view_command,
+)
+from trinity.common.config import Config
+
+runner = CliRunner()
+
+
+def _build_config(**pipeline_overrides) -> Config:
+    """Build a minimal Config suitable for view resolution (no validation)."""
+    config = Config()
+    config.checkpoint_root_dir = tempfile.mkdtemp()
+    config.project = "Proj"
+    config.group = "Grp"
+    config.name = "run1"
+    config.model.model_path = "/path/to/model"
+    pipeline = config.data_processor.experience_pipeline
+    pipeline.save_input = pipeline_overrides.pop("save_input", True)
+    pipeline.input_save_path = pipeline_overrides.pop("input_save_path", None)
+    return config
+
+
+class TestResolveDbUrl(unittest.TestCase):
+    def test_plain_relative_path_converted_to_sqlite_url(self):
+        # A bare path is resolved against CWD and prefixed with sqlite:///.
+        resolved = _resolve_db_url("debug_buffer.db")
+        self.assertTrue(resolved.startswith("sqlite:///"))
+        self.assertTrue(resolved.endswith("debug_buffer.db"))
+        self.assertTrue(os.path.isabs(resolved[len("sqlite:///") :]))
+
+    def test_plain_absolute_path_converted(self):
+        abs_path = os.path.abspath("debug_buffer.db")
+        resolved = _resolve_db_url(abs_path)
+        # Absolute paths yield the four-slash sqlite URL form: "sqlite:///" + "/abs/...".
+        self.assertEqual(resolved, "sqlite:///" + abs_path)
+
+    def test_existing_sqlite_url_passthrough(self):
+        url = "sqlite:////tmp/abs/debug_buffer.db"
+        self.assertEqual(_resolve_db_url(url), url)
+
+    def test_postgres_url_passthrough(self):
+        url = "postgresql://user:pass@host:5432/db"
+        self.assertEqual(_resolve_db_url(url), url)
+
+    def test_mysql_url_passthrough(self):
+        url = "mysql://user:pass@host/db"
+        self.assertEqual(_resolve_db_url(url), url)
+
+
+class TestDefaultInputSavePath(unittest.TestCase):
+    def test_produces_sqlite_url_under_buffer_cache(self):
+        from trinity.buffer.pipelines.experience_pipeline import default_input_save_path
+
+        config = _build_config()
+        path = default_input_save_path(config)
+        self.assertTrue(path.startswith("sqlite:///"))
+        self.assertTrue(path.endswith("explorer_output.db"))
+        self.assertIn("buffer", path)
+        self.assertIn(os.path.join("Proj", "Grp", "run1"), path)
+
+    def test_abs_path_matches_validator_derivation(self):
+        # The pipeline-owned default must equal what the validator used to set:
+        # sqlite:///<checkpoint_job_dir>/buffer/explorer_output.db (abs-ified).
+        from trinity.buffer.pipelines.experience_pipeline import default_input_save_path
+
+        config = _build_config()
+        expected_cache = os.path.abspath(os.path.join(config.get_checkpoint_job_dir(), "buffer"))
+        expected = "sqlite:///" + os.path.join(expected_cache, "explorer_output.db")
+        self.assertEqual(default_input_save_path(config), expected)
+
+
+class TestResolveFromConfig(unittest.TestCase):
+    def _patch_load(self, config: Config):
+        return mock.patch("trinity.common.config.load_config", return_value=config)
+
+    def test_save_input_false_is_rejected(self):
+        config = _build_config(save_input=False, input_save_path="sqlite:///x.db")
+        with self._patch_load(config):
+            with self.assertRaises(typer.BadParameter):
+                _resolve_from_config("dummy.yaml")
+
+    def test_json_save_path_is_rejected(self):
+        config = _build_config(input_save_path="/tmp/foo.jsonl")
+        with self._patch_load(config):
+            with self.assertRaises(typer.BadParameter):
+                _resolve_from_config("dummy.yaml")
+
+    def test_none_input_save_path_uses_pipeline_default(self):
+        config = _build_config(input_save_path=None)
+        from trinity.buffer.pipelines.experience_pipeline import default_input_save_path
+
+        with self._patch_load(config):
+            db_url, table, tokenizer = _resolve_from_config("dummy.yaml")
+        self.assertEqual(db_url, default_input_save_path(config))
+        self.assertEqual(table, "pipeline_input")
+        self.assertEqual(tokenizer, config.model.model_path)
+
+    def test_explicit_db_url_is_used(self):
+        config = _build_config(input_save_path="sqlite:////explicit/buffer.db")
+        with self._patch_load(config):
+            db_url, table, tokenizer = _resolve_from_config("dummy.yaml")
+        self.assertEqual(db_url, "sqlite:////explicit/buffer.db")
+        self.assertEqual(table, "pipeline_input")
+        self.assertEqual(tokenizer, config.model.model_path)
+
+    def test_missing_model_path_is_rejected(self):
+        config = _build_config(input_save_path="sqlite:///x.db")
+        config.model.model_path = ""
+        with self._patch_load(config):
+            with self.assertRaises(typer.BadParameter):
+                _resolve_from_config("dummy.yaml")
+
+
+class TestWarnIfRenamed(unittest.TestCase):
+    def _capture(self):
+        calls = []
+        patcher = mock.patch("typer.secho", side_effect=lambda *a, **k: calls.append(a[0]))
+        return patcher, calls
+
+    def test_silent_when_continue_from_checkpoint(self):
+        config = _build_config()
+        config.continue_from_checkpoint = True
+        os.makedirs(os.path.join(config.get_checkpoint_job_dir(), "buffer"), exist_ok=True)
+        patcher, calls = self._capture()
+        with patcher:
+            _warn_if_renamed(config)
+        self.assertEqual(calls, [])
+
+    def test_silent_when_job_dir_missing(self):
+        config = _build_config()
+        config.continue_from_checkpoint = False
+        # job dir does not exist on disk -> no rename happened
+        patcher, calls = self._capture()
+        with patcher:
+            _warn_if_renamed(config)
+        self.assertEqual(calls, [])
+
+    def test_warns_and_lists_candidates_when_renamed(self):
+        config = _build_config()
+        config.continue_from_checkpoint = False
+        job_dir = config.get_checkpoint_job_dir()
+        # The clean dir exists and is non-empty (rename condition).
+        os.makedirs(os.path.join(job_dir, "buffer"), exist_ok=True)
+        # A timestamped sibling that actually holds the data.
+        sibling = f"{job_dir}_20260101000000"
+        os.makedirs(os.path.join(sibling, "buffer"), exist_ok=True)
+        try:
+            patcher, calls = self._capture()
+            with patcher:
+                _warn_if_renamed(config)
+            self.assertEqual(len(calls), 1)
+            self.assertIn("auto-renamed", calls[0])
+            self.assertIn(os.path.basename(sibling), calls[0])
+        finally:
+            import shutil
+
+            shutil.rmtree(sibling, ignore_errors=True)
+
+
+class TestViewCommandCli(unittest.TestCase):
+    """Drive the typer-decorated view_command via a throwaway app."""
+
+    def _app(self):
+        app = typer.Typer()
+        app.command()(view_command)
+        return app
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_url_plain_path(self, mock_run):
+        result = runner.invoke(
+            self._app(), ["--url", "debug_buffer.db", "--table", "t", "--tokenizer", "/m"]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        _, kwargs = mock_run.call_args
+        self.assertTrue(kwargs["db_url"].startswith("sqlite:///"))
+        self.assertTrue(kwargs["db_url"].endswith("debug_buffer.db"))
+        self.assertEqual(kwargs["table_name"], "t")
+        self.assertEqual(kwargs["model_path"], "/m")
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_url_existing_url_passthrough(self, mock_run):
+        result = runner.invoke(
+            self._app(),
+            ["--url", "sqlite:////abs/debug.db", "--table", "t", "--tokenizer", "/m"],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(mock_run.call_args.kwargs["db_url"], "sqlite:////abs/debug.db")
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_config_resolves_values(self, mock_run):
+        config = _build_config(input_save_path="sqlite:////cfg/buffer.db")
+        with mock.patch("trinity.common.config.load_config", return_value=config):
+            result = runner.invoke(self._app(), ["--config", "dummy.yaml"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        _, kwargs = mock_run.call_args
+        self.assertEqual(kwargs["db_url"], "sqlite:////cfg/buffer.db")
+        self.assertEqual(kwargs["table_name"], "pipeline_input")
+        self.assertEqual(kwargs["model_path"], config.model.model_path)
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_explicit_cli_overrides_config(self, mock_run):
+        config = _build_config(input_save_path="sqlite:////cfg/buffer.db")
+        with mock.patch("trinity.common.config.load_config", return_value=config):
+            result = runner.invoke(
+                self._app(),
+                [
+                    "--config",
+                    "dummy.yaml",
+                    "--url",
+                    "override.db",
+                    "--table",
+                    "override_table",
+                    "--tokenizer",
+                    "/override_model",
+                ],
+            )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        _, kwargs = mock_run.call_args
+        self.assertTrue(kwargs["db_url"].endswith("override.db"))
+        self.assertEqual(kwargs["table_name"], "override_table")
+        self.assertEqual(kwargs["model_path"], "/override_model")
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_config_rejects_save_input_false(self, mock_run):
+        config = _build_config(save_input=False, input_save_path="sqlite:///x.db")
+        with mock.patch("trinity.common.config.load_config", return_value=config):
+            result = runner.invoke(self._app(), ["--config", "dummy.yaml"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("save_input", result.output)
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_missing_url_and_config_errors(self, mock_run):
+        result = runner.invoke(self._app(), ["--table", "t", "--tokenizer", "/m"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--url", result.output)
+
+    @mock.patch("trinity.buffer.viewer.SQLExperienceViewer.run_viewer")
+    def test_missing_table_without_config_errors(self, mock_run):
+        result = runner.invoke(self._app(), ["--url", "debug.db", "--tokenizer", "/m"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--table", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trinity/buffer/pipelines/experience_pipeline.py
+++ b/trinity/buffer/pipelines/experience_pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 import traceback
 from typing import Dict, Optional
@@ -31,6 +32,23 @@ def get_input_buffers(pipeline_config: ExperiencePipelineConfig) -> Dict:
     return input_buffers
 
 
+def default_input_save_path(config: Config) -> str:
+    """Compute the default ``input_save_path`` for the experience pipeline.
+
+    This is the single source of truth for where the pipeline writes its input
+    database when ``save_input`` is enabled but no path is provided: a SQLite
+    database at ``<checkpoint_job_dir>/buffer/explorer_output.db``.
+
+    It is derived purely from the config components (no Ray/GPU side effects), so
+    callers that load a config without a full validation pass — e.g. ``trinity view``
+    — resolve the exact same path the pipeline writes to at run time. The
+    ``abspath`` mirrors ``GlobalConfigValidator`` making a relative
+    ``checkpoint_root_dir`` absolute, keeping the two contexts consistent.
+    """
+    cache_dir = os.path.abspath(os.path.join(config.get_checkpoint_job_dir(), "buffer"))
+    return "sqlite:///" + os.path.join(cache_dir, "explorer_output.db")
+
+
 class ExperiencePipeline:
     """
     A class to process experiences.
@@ -54,8 +72,15 @@ class ExperiencePipeline:
         """Initialize the input storage if it is not already set."""
         if pipeline_config.save_input:
             if pipeline_config.input_save_path is None:
-                raise ValueError("input_save_path must be set when save_input is True.")
-            elif is_json_file(pipeline_config.input_save_path):
+                # The pipeline owns this default — it is the component that actually
+                # creates the database. Resolved here (rather than in a config
+                # validator) so it works regardless of whether full validation runs.
+                pipeline_config.input_save_path = default_input_save_path(self.config)
+                self.logger.info(
+                    "Auto set `data_processor.experience_pipeline.input_save_path` "
+                    f"to {pipeline_config.input_save_path}"
+                )
+            if is_json_file(pipeline_config.input_save_path):
                 return get_buffer_writer(
                     StorageConfig(
                         storage_type=StorageType.FILE.value,

--- a/trinity/buffer/viewer.py
+++ b/trinity/buffer/viewer.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -18,19 +19,46 @@ class _SyncViewerStorage:
 
     def __init__(self, config: StorageConfig) -> None:
         self._loop = asyncio.new_event_loop()
+        self._loop_ready = threading.Event()
+        self._closed = False
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        self._loop_ready.wait()
         self._async = SQLExperienceStorage(config)
-        self._loop.run_until_complete(self._async.prepare())
+        self._run(self._async.prepare())
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop_ready.set()
+        self._loop.run_forever()
+
+    def _submit(self, coro):
+        if self._closed:
+            raise RuntimeError("Viewer storage has been closed.")
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
 
     def _run(self, coro):
-        return self._loop.run_until_complete(coro)
+        return self._submit(coro).result()
 
     def close(self):
-        if self._loop and not self._loop.is_closed():
-            self._loop.run_until_complete(self._async.engine.dispose())
-            self._loop.close()
+        if self._closed:
+            return
+
+        try:
+            if hasattr(self, "_async") and hasattr(self._async, "engine"):
+                self._run(self._async.engine.dispose())
+        finally:
+            if self._loop and not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._loop.stop)
+                self._thread.join(timeout=5)
+                self._loop.close()
+            self._closed = True
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def query(self, offset: int = 0, limit: int = 10, filters=None) -> List[Experience]:
         return self._run(self._async.query(offset, limit, filters))
@@ -254,6 +282,13 @@ def main():  # noqa: [C901]
     if "page" not in st.session_state:
         st.session_state.page = 1
 
+    def _set_page(page: int) -> None:
+        st.session_state.page = page
+        st.session_state.page_input = page
+
+    def _sync_page_from_input() -> None:
+        st.session_state.page = st.session_state.page_input
+
     # === Sidebar: Filters ===
     st.sidebar.header("Filters")
 
@@ -314,7 +349,12 @@ def main():  # noqa: [C901]
 
     # Clamp current page
     if st.session_state.page > total_pages:
-        st.session_state.page = total_pages
+        _set_page(total_pages)
+
+    if "page_input" not in st.session_state:
+        st.session_state.page_input = st.session_state.page
+    elif st.session_state.page_input != st.session_state.page:
+        st.session_state.page_input = st.session_state.page
 
     # Calculate offset and fetch
     offset = (st.session_state.page - 1) * experiences_per_page
@@ -348,22 +388,22 @@ def main():  # noqa: [C901]
     # Row 1: Previous | [current_page] / total_pages | Next
     col_prev, col_page_input, col_slash, col_total, col_next = st.columns([1, 1, 0.3, 0.7, 1])
     with col_prev:
-        if st.button("Previous", disabled=(st.session_state.page <= 1)):
-            st.session_state.page -= 1
-            st.rerun()
+        st.button(
+            "Previous",
+            disabled=(st.session_state.page <= 1),
+            on_click=_set_page,
+            args=(st.session_state.page - 1,),
+        )
     with col_page_input:
-        new_page = st.number_input(
+        st.number_input(
             "page",
             min_value=1,
             max_value=total_pages,
-            value=st.session_state.page,
             step=1,
             label_visibility="collapsed",
             key="page_input",
+            on_change=_sync_page_from_input,
         )
-        if new_page != st.session_state.page:
-            st.session_state.page = new_page
-            st.rerun()
     with col_slash:
         st.markdown(
             "<div style='text-align:center;line-height:38px;'>/</div>",
@@ -375,9 +415,12 @@ def main():  # noqa: [C901]
             unsafe_allow_html=True,
         )
     with col_next:
-        if st.button("Next", disabled=(st.session_state.page >= total_pages)):
-            st.session_state.page += 1
-            st.rerun()
+        st.button(
+            "Next",
+            disabled=(st.session_state.page >= total_pages),
+            on_click=_set_page,
+            args=(st.session_state.page + 1,),
+        )
 
     # Row 2: total count
     st.caption(f"{total_seq_num} experiences in total")

--- a/trinity/cli/view.py
+++ b/trinity/cli/view.py
@@ -37,7 +37,14 @@ def _resolve_from_config(config_path: str) -> tuple[str, str, str]:
             "so no input database is produced."
         )
     save_path = pipeline_cfg.input_save_path
-    if not save_path or not is_database_url(save_path):
+    if save_path is None:
+        # save_input is on but no path given: the pipeline writes a SQLite DB
+        # under the buffer cache dir. Resolve the same default so `view` works
+        # without a full config validation pass.
+        from trinity.buffer.pipelines.experience_pipeline import default_input_save_path
+
+        save_path = default_input_save_path(config)
+    if not is_database_url(save_path):
         raise typer.BadParameter(
             f"Cannot view from {config_path}: "
             "data_processor.experience_pipeline.input_save_path "
@@ -48,9 +55,45 @@ def _resolve_from_config(config_path: str) -> tuple[str, str, str]:
     if not tokenizer_path:
         raise typer.BadParameter(f"Cannot view from {config_path}: model.model_path is not set.")
 
+    _warn_if_renamed(config)
+
     # Mirrors ExperiencePipeline: the SQL input writer is created with table
     # name "pipeline_input" (see trinity/buffer/pipelines/experience_pipeline.py).
     return save_path, "pipeline_input", tokenizer_path
+
+
+def _warn_if_renamed(config) -> None:
+    """Warn if the resolved path may not match where the DB was actually written.
+
+    At run time, ``GlobalConfigValidator`` auto-renames an experiment (appending a
+    timestamp to ``name``) when ``continue_from_checkpoint`` is False and the job
+    directory already exists and is non-empty. Since ``view`` resolves the clean
+    (pre-rename) path, the database in that case lives under a timestamped sibling
+    ``<name>_<timestamp>/`` and the clean path may be stale or point at a different run.
+    """
+    import glob
+
+    job_dir = config.get_checkpoint_job_dir()
+    if config.continue_from_checkpoint or not os.path.isdir(job_dir) or not os.listdir(job_dir):
+        return
+
+    parent = os.path.dirname(job_dir)
+    candidates = sorted(
+        d for d in glob.glob(os.path.join(parent, f"{config.name}_*")) if os.path.isdir(d)
+    )
+    hint = ""
+    if candidates:
+        hint = " Likely candidate(s): " + ", ".join(os.path.basename(d) for d in candidates)
+
+    typer.secho(
+        "Warning: experiment was likely auto-renamed at run time "
+        "(continue_from_checkpoint=False and the job directory already exists). "
+        f"The resolved database path is under {job_dir!r}, but the actual database "
+        f"is probably under a timestamped sibling {config.name}_<timestamp>/.{hint} "
+        "Pass --url directly at the database file to avoid ambiguity.",
+        fg=typer.colors.YELLOW,
+        err=True,
+    )
 
 
 def view_command(

--- a/trinity/cli/view.py
+++ b/trinity/cli/view.py
@@ -14,7 +14,7 @@ def _resolve_db_url(url: str) -> str:
     """
     if "://" in url:
         return url
-    return "sqlite:///" + os.path.abspath(url)
+    return "sqlite:///" + os.path.abspath(os.path.expanduser(url))
 
 
 def _resolve_from_config(config_path: str) -> tuple[str, str, str]:
@@ -89,7 +89,7 @@ def _warn_if_renamed(config) -> None:
         "Warning: experiment was likely auto-renamed at run time "
         "(continue_from_checkpoint=False and the job directory already exists). "
         f"The resolved database path is under {job_dir!r}, but the actual database "
-        f"is probably under a timestamped sibling {config.name}_<timestamp>/.{hint} "
+        f"is probably under a timestamped sibling {config.name}_<timestamp>/{hint} "
         "Pass --url directly at the database file to avoid ambiguity.",
         fg=typer.colors.YELLOW,
         err=True,

--- a/trinity/cli/view.py
+++ b/trinity/cli/view.py
@@ -1,26 +1,93 @@
+import os
+from typing import Optional
+
 import typer
 from typing_extensions import Annotated
 
 
+def _resolve_db_url(url: str) -> str:
+    """Normalize a database specifier into a connection URL.
+
+    Accepts a plain path to a ``.db`` file (relative or absolute) and converts
+    it to a ``sqlite:///`` URL. Anything that already looks like a DB URL
+    (``sqlite:///``, ``postgresql://``, ...) is passed through unchanged.
+    """
+    if "://" in url:
+        return url
+    return "sqlite:///" + os.path.abspath(url)
+
+
+def _resolve_from_config(config_path: str) -> tuple[str, str, str]:
+    """Resolve (db_url, table_name, tokenizer_path) from a Trinity config file.
+
+    Reads the experience pipeline's saved input. The viewer is only usable when
+    the pipeline actually writes a SQL database, so requests are rejected when
+    ``save_input`` is disabled or ``input_save_path`` is not a database URL.
+    """
+    from trinity.buffer.storage.queue import is_database_url
+    from trinity.common.config import load_config
+
+    config = load_config(config_path)
+    pipeline_cfg = config.data_processor.experience_pipeline
+
+    if not pipeline_cfg.save_input:
+        raise typer.BadParameter(
+            f"Cannot view from {config_path}: "
+            "data_processor.experience_pipeline.save_input is False, "
+            "so no input database is produced."
+        )
+    save_path = pipeline_cfg.input_save_path
+    if not save_path or not is_database_url(save_path):
+        raise typer.BadParameter(
+            f"Cannot view from {config_path}: "
+            "data_processor.experience_pipeline.input_save_path "
+            f"({save_path!r}) is not a database URL, so no SQL database is produced."
+        )
+
+    tokenizer_path = config.model.model_path
+    if not tokenizer_path:
+        raise typer.BadParameter(f"Cannot view from {config_path}: model.model_path is not set.")
+
+    # Mirrors ExperiencePipeline: the SQL input writer is created with table
+    # name "pipeline_input" (see trinity/buffer/pipelines/experience_pipeline.py).
+    return save_path, "pipeline_input", tokenizer_path
+
+
 def view_command(
     url: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--url",
-            help="Database URL for the experience table, for example sqlite:////path/to/debug_buffer.db.",
+            help=(
+                "Database specifier for the experience table. Accepts either a DB URL "
+                "(e.g. sqlite:////path/to/debug_buffer.db) or a plain path to a .db file "
+                "(relative or absolute), which is converted to a sqlite URL automatically. "
+                "Optional when --config is given; a value here overrides the config."
+            ),
         ),
-    ],
+    ] = None,
     table: Annotated[
-        str,
+        Optional[str],
         typer.Option("--table", help="Name of the experience table to monitor."),
-    ],
+    ] = None,
     tokenizer: Annotated[
-        str,
+        Optional[str],
         typer.Option(
             "--tokenizer",
             help="Tokenizer/model path used to decode token ids in the viewer.",
         ),
-    ],
+    ] = None,
+    config: Annotated[
+        Optional[str],
+        typer.Option(
+            "--config",
+            help=(
+                "Path to a Trinity config file. When set, --url/--tokenizer/--table are "
+                "inferred from it (experience pipeline input database + model.model_path); "
+                "explicit CLI args still override the config."
+            ),
+        ),
+    ] = None,
     schema: Annotated[
         str,
         typer.Option(
@@ -34,16 +101,38 @@ def view_command(
     ] = 8502,
 ) -> None:
     """Run the Streamlit viewer to inspect an experience table."""
-    from trinity.buffer.viewer import SQLExperienceViewer
-
     schema = schema.lower()
     if schema not in {"experience", "sft"}:
         raise typer.BadParameter("--schema only supports 'experience' or 'sft'.")
 
+    db_url: Optional[str] = None
+    table_name: Optional[str] = None
+    tokenizer_path: Optional[str] = None
+
+    if config is not None:
+        db_url, table_name, tokenizer_path = _resolve_from_config(config)
+
+    # Explicit CLI arguments take precedence over config-derived values.
+    if url is not None:
+        db_url = _resolve_db_url(url)
+    if table is not None:
+        table_name = table
+    if tokenizer is not None:
+        tokenizer_path = tokenizer
+
+    if db_url is None:
+        raise typer.BadParameter("--url is required (or provide --config).")
+    if table_name is None:
+        raise typer.BadParameter("--table is required (or provide --config).")
+    if tokenizer_path is None:
+        raise typer.BadParameter("--tokenizer is required (or provide --config).")
+
+    from trinity.buffer.viewer import SQLExperienceViewer
+
     SQLExperienceViewer.run_viewer(
-        model_path=tokenizer,
-        db_url=url,
-        table_name=table,
+        model_path=tokenizer_path,
+        db_url=db_url,
+        table_name=table_name,
         schema_type=schema,
         port=port,
     )

--- a/trinity/common/config_validator.py
+++ b/trinity/common/config_validator.py
@@ -1204,15 +1204,10 @@ class BufferConfigValidator(ConfigValidator):
             "serve",
             "colocate",
         }:
-            if experience_pipeline.save_input and experience_pipeline.input_save_path is None:
-                experience_pipeline.input_save_path = self._default_storage_path(
-                    config, StorageType.SQL.value, "explorer_output"
-                )
-                self.logger.info(
-                    "Auto set `data_processor.experience_pipeline.input_save_path` "
-                    f"to {experience_pipeline.input_save_path}"
-                )
-
+            # NOTE: the default for `experience_pipeline.input_save_path` is
+            # resolved by ExperiencePipeline._init_input_storage (the component
+            # that actually creates the database), so that callers without a
+            # full validation pass (e.g. `trinity view`) resolve the same path.
             if config.service.data_juicer is not None:
                 for operator in experience_pipeline.operators:
                     if operator.name == "data_juicer":

--- a/trinity/utils/dlc_utils.py
+++ b/trinity/utils/dlc_utils.py
@@ -85,15 +85,34 @@ def setup_ray_cluster(namespace: str) -> str:
     else:
         if is_master:
             cmd = f"ray start --head --port={env_vars['MASTER_PORT']} --node-ip-address={env_vars['MASTER_ADDR']}"
+            ret = subprocess.run(cmd, shell=True, capture_output=True)
+            logger.info(f"Starting ray cluster: {cmd}")
+            if ret.returncode != 0:
+                logger.error(f"Failed to start ray cluster: {cmd}")
+                logger.error(f"ret.stdout: {ret.stdout!r}")
+                logger.error(f"ret.stderr: {ret.stderr!r}")
+                sys.exit(1)
         else:
             cmd = f"ray start --address={env_vars['MASTER_ADDR']}:{env_vars['MASTER_PORT']}"
-        ret = subprocess.run(cmd, shell=True, capture_output=True)
-        logger.info(f"Starting ray cluster: {cmd}")
-        if ret.returncode != 0:
-            logger.error(f"Failed to start ray cluster: {cmd}")
-            logger.error(f"ret.stdout: {ret.stdout!r}")
-            logger.error(f"ret.stderr: {ret.stderr!r}")
-            sys.exit(1)
+            logger.info(f"Starting ray worker: {cmd}")
+            retry_timeout = 600  # 10 minutes
+            retry_interval = 5
+            start_time = time.time()
+            while True:
+                ret = subprocess.run(cmd, shell=True, capture_output=True)
+                if ret.returncode == 0:
+                    break
+                elapsed = time.time() - start_time
+                if elapsed >= retry_timeout:
+                    logger.error(f"Failed to start ray worker after {retry_timeout}s: {cmd}")
+                    logger.error(f"ret.stdout: {ret.stdout!r}")
+                    logger.error(f"ret.stderr: {ret.stderr!r}")
+                    sys.exit(1)
+                logger.warning(
+                    f"Ray worker failed to connect to master (elapsed {elapsed:.0f}s), "
+                    f"retrying in {retry_interval}s..."
+                )
+                time.sleep(retry_interval)
 
         wait_for_ray_setup()
         time.sleep(5)


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the experience viewer functionality in Trinity, focusing on improving usability, configurability, and robustness. The main changes include adding a single-source-of-truth function for the default experience database path, improving the CLI and documentation for the `trinity view` command, refactoring the viewer's storage backend for safer async handling, and enhancing the Streamlit UI for experience browsing. Comprehensive tests for the viewer CLI and config resolution logic have also been added.

**Experience viewer usability and documentation:**

* Added detailed FAQ entries (English and Chinese) on how to inspect experiences generated during training, including usage examples for the `trinity view` command and configuration requirements. [[1]](diffhunk://#diff-2a44eb63b479cc8d48e254d3d28a4bfd78cd67c50721037d59dab560d2bf80e7R154-R182) [[2]](diffhunk://#diff-c594ee97850aed04d986b361679a0faa5df126aa7b35f0974fdcbd5a1854a8bdR147-R176)

**Configuration and default path handling:**

* Introduced `default_input_save_path` in `experience_pipeline.py` as the authoritative method for determining the default SQLite database path for experience data, ensuring consistent path resolution between pipeline execution and CLI tools.
* Modified the pipeline to set `input_save_path` automatically using this function if not explicitly configured, logging the chosen path for transparency.

**Viewer CLI and config resolution:**

* Added a comprehensive test suite (`tests/cli/view_test.py`) covering CLI argument parsing, config-based resolution of database paths, table names, and tokenizer paths, as well as edge cases like path overrides and error handling.

**Viewer backend and UI improvements:**

* Refactored the viewer's synchronous storage wrapper to use a dedicated thread for its event loop, improving thread safety and resource cleanup.
* Improved Streamlit pagination controls for a smoother user experience, including better state synchronization and page input handling. [[1]](diffhunk://#diff-dfc01093126698e1e425b3ed6a49291d071999c09db41c4afee43666c009cf1dR285-R291) [[2]](diffhunk://#diff-dfc01093126698e1e425b3ed6a49291d071999c09db41c4afee43666c009cf1dL317-R357) [[3]](diffhunk://#diff-dfc01093126698e1e425b3ed6a49291d071999c09db41c4afee43666c009cf1dL351-L366) [[4]](diffhunk://#diff-dfc01093126698e1e425b3ed6a49291d071999c09db41c4afee43666c009cf1dL378-R423)

**Miscellaneous:**

* Minor import and threading-related adjustments to support the above changes. [[1]](diffhunk://#diff-76a90fbaaed4da0341750678e6529cf08d6fd45787e0ed5876bb32b373f225e9R2) [[2]](diffhunk://#diff-dfc01093126698e1e425b3ed6a49291d071999c09db41c4afee43666c009cf1dR4)


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review
