### PR TITLE
Set CoD train configs to both mode

### DIFF
--- a/examples/research_cod/exp_plan_final/train/alchemy_abl_no_adaptive_red.yaml
+++ b/examples/research_cod/exp_plan_final/train/alchemy_abl_no_adaptive_red.yaml
@@ -4,7 +4,7 @@
 project: "trinity-cod-final"
 group: "alchemy_abl_no_adaptive_red"
 name: "qwen3-8b-alchemy"
-mode: train
+mode: both
 checkpoint_root_dir: ${oc.env:TRINITY_CHECKPOINT_ROOT_DIR,./checkpoints}
 continue_from_checkpoint: false
 cod:

--- a/examples/research_cod/exp_plan_final/train/alchemy_abl_no_adaptive_red_is.yaml
+++ b/examples/research_cod/exp_plan_final/train/alchemy_abl_no_adaptive_red_is.yaml
@@ -5,7 +5,7 @@
 project: "trinity-cod-final"
 group: "alchemy_abl_no_adaptive_red_is"
 name: "qwen3-8b-alchemy"
-mode: train
+mode: both
 checkpoint_root_dir: ${oc.env:TRINITY_CHECKPOINT_ROOT_DIR,./checkpoints}
 continue_from_checkpoint: false
 cod:

--- a/examples/research_cod/exp_plan_final/train/frozen_lake_obscure.yaml
+++ b/examples/research_cod/exp_plan_final/train/frozen_lake_obscure.yaml
@@ -3,7 +3,7 @@
 project: "trinity-cod-final"
 group: "frozen_lake_obscure"
 name: "qwen3-8b-flobs"
-mode: train
+mode: both
 checkpoint_root_dir: ${oc.env:TRINITY_CHECKPOINT_ROOT_DIR,./checkpoints}
 continue_from_checkpoint: false
 cod:

--- a/examples/research_cod/exp_plan_final/train/mixed_flobs_alchran.yaml
+++ b/examples/research_cod/exp_plan_final/train/mixed_flobs_alchran.yaml
@@ -4,7 +4,7 @@
 project: "trinity-cod-final"
 group: "mixed_flobs_alchran"
 name: "qwen3-8b-mixed"
-mode: train
+mode: both
 checkpoint_root_dir: ${oc.env:TRINITY_CHECKPOINT_ROOT_DIR,./checkpoints}
 continue_from_checkpoint: false
 cod:


### PR DESCRIPTION
`mode: train` only launches the trainer, leaving these GRPO configs waiting for rollout data that never arrives. CoD training needs the explorer and the trainer together, i.e. `mode: both`.