### PR TITLE
Raise runner prepare defaults

### DIFF
--- a/trinity/common/config.py
+++ b/trinity/common/config.py
@@ -733,8 +733,8 @@ class ExplorerConfig:
     # for workflow runner
     # number of workflow runners.
     runner_per_model: int = 8  # number of runners per each rollout model
-    runner_prepare_concurrency: int = 8  # cap concurrent prepares (glibc getenv race)
-    runner_prepare_max_retries: int = 2  # retry prepare on transient crash
+    runner_prepare_concurrency: int = 128  # cap concurrent prepares (glibc getenv race)
+    runner_prepare_max_retries: int = 3  # retry prepare on transient crash
     max_timeout: int = 1800  # wait each task for 30 minutes at most
     max_retry_times: int = 2  # retry each task for 2 times if it fails or timeout
     env_vars: dict = field(default_factory=dict)  # environment variables for workflow runner


### PR DESCRIPTION
## Summary

- Raise the default `runner_prepare_concurrency` from 8 to 128.
- Increase `runner_prepare_max_retries` from 2 to 3.

## Motivation

The current default concurrency of 8 can slow down large workflow-runner cold starts. In DLC profiling, each runner prepare can take around 70 seconds, so preparing many runners in batches of 8 can noticeably delay startup and GPU utilization.

The 128 value keeps a conservative default guardrail for mass startup. If maintainers prefer simpler behavior, keeping only the retry mechanism may also be enough, since transient runner-prepare failures are already retried.

## Checks

- `python -m py_compile trinity/common/config.py`