### PR TITLE
fix(qwen3.5): read layer types from model config

### DIFF
--- a/trinity/trainer/verl_legacy/monkey_patch.py
+++ b/trinity/trainer/verl_legacy/monkey_patch.py
@@ -440,8 +440,10 @@ def apply_monkey_patch(  # noqa: C901
 
             from trinity.common.patch.qwen3_5 import ulysses_gate_delta_net_decorator
 
-            for layer in model.model.language_model.layers:
-                if layer.layer_type == "linear_attention":
+            language_model = model.model.language_model
+            for layer_idx, layer in enumerate(language_model.layers):
+                layer_type = language_model.config.layer_types[layer_idx]
+                if layer_type == "linear_attention":
                     ulysses_gate_delta_net_decorator(layer.linear_attn, ulysses_sp_size)
 
         # Step 3: patch verl.utils.flops_counter


### PR DESCRIPTION
## Problem

With Ulysses sequence parallelism enabled, newer Qwen3.5 model implementations may not expose `layer_type` on each decoder layer. The monkey patch then fails before patching linear-attention layers with:

```text
AttributeError: 'Qwen3_5DecoderLayer' object has no attribute 'layer_type'
```

## Fix

Read each layer type from the model configuration's `layer_types` list instead of relying on a per-layer attribute. This keeps linear-attention layer detection aligned with the model config.
